### PR TITLE
Implemented weekly command.

### DIFF
--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -9,14 +7,14 @@ using MaraBot.Messages;
 
 namespace MaraBot.Commands
 {
-    public class CompletedCommandModule : BaseCommandModule
+    public class LeaderboardCommandModule : BaseCommandModule
     {
         public Weekly Weekly { private get; set; }
 
-        [Command("completed")]
-        [Cooldown(2, 900, CooldownBucketType.User)]
+        [Command("leaderboard")]
+        [Cooldown(5, 900, CooldownBucketType.User)]
         [RequireGuild]
-        public async Task Execute(CommandContext ctx, TimeSpan time)
+        public async Task Execute(CommandContext ctx)
         {
             var weekNumber = RandomUtils.GetWeekNumber();
             if (Weekly.WeekNumber != weekNumber)
@@ -27,17 +25,6 @@ namespace MaraBot.Commands
                 await ctx.Message.CreateReactionAsync(invalidEmoji);
             }
 
-            var username = ctx.User.Username;
-
-            if (Weekly.Leaderboard == null)
-                Weekly.Leaderboard = new Dictionary<string, TimeSpan>();
-
-            if (Weekly.Leaderboard.ContainsKey(username))
-                Weekly.Leaderboard[username] = time;
-            else
-                Weekly.Leaderboard.Add(username, time);
-
-            WeeklyIO.StoreWeekly(Weekly);
             await Display.Leaderboard(ctx, Weekly);
 
             var validEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -9,12 +9,12 @@ namespace MaraBot.Commands
 {
     using Core;
     using Messages;
-    
+
     public class WeeklyCommandModule : BaseCommandModule
     {
         public Weekly Weekly { private get; set; }
         public IReadOnlyDictionary<string, Preset> Presets { private get; set; }
-        
+
         [Command("weekly")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
@@ -29,19 +29,21 @@ namespace MaraBot.Commands
                 WeeklyIO.StoreWeekly(Weekly);
             }
 
-            if (!Presets.ContainsKey(Weekly.PresetName))
+            if (!Presets.ContainsKey(Weekly.PresetName) || Weekly.WeekNumber < 0)
             {
-                await ctx.RespondAsync($"{Weekly.PresetName} is not a a valid preset");
-                
+                await ctx.RespondAsync(
+                    $"Weekly preset '{Weekly.PresetName}' is not a a valid preset\n" +
+                    "This shouldn't happen! Please contact your friendly neighbourhood developers!");
+
                 var invalidEmoji = DiscordEmoji.FromName(ctx.Client, Display.kInvalidCommandEmoji);
                 await ctx.Message.CreateReactionAsync(invalidEmoji);
-                
-                return; 
+
+                return;
             }
-            
+
             var preset = Presets[Weekly.PresetName];
             await Display.Race(ctx, preset, Weekly.Seed);
-                        
+
             var successEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);
             await ctx.Message.CreateReactionAsync(successEmoji);
         }

--- a/MaraBot/Core/Config.cs
+++ b/MaraBot/Core/Config.cs
@@ -1,16 +1,9 @@
 
 namespace MaraBot.Core
 {
-    public interface IWeeklyConfig
+    public struct Config
     {
-        int Seed { get; }
-    }
-
-    public struct Config : IWeeklyConfig
-    {
+        public string Prefix;
         public string Token;
-        public int WeeklySeed;
-
-        int IWeeklyConfig.Seed => WeeklySeed;
     }
 }

--- a/MaraBot/Core/ConfigIO.cs
+++ b/MaraBot/Core/ConfigIO.cs
@@ -11,10 +11,11 @@ namespace MaraBot.Core
     {
         static readonly string[] k_ConfigFolders = new []
         {
-            "$HOME/marabot/config",
             "config",
             "../../../config",
-            "../../../../config"
+            "../../../../config",
+            "$HOME/marabot/config",
+            "$HOME/marabot"
         };
         
         public static Config LoadConfig()
@@ -25,20 +26,13 @@ namespace MaraBot.Core
                     ? Environment.GetEnvironmentVariable("HOME")
                     : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
             
-            var configFolder = k_ConfigFolders
-                .Select(path => path.Replace("$HOME", homeFolder))
-                .FirstOrDefault(path => Directory.Exists(path));
+            var configPath = k_ConfigFolders
+                .Select(path => path.Replace("$HOME", homeFolder) + "/config.json")
+                .FirstOrDefault(path => File.Exists(path));
 
-            if (String.IsNullOrEmpty(configFolder))
+            if (String.IsNullOrEmpty(configPath))
             {
-                throw new InvalidOperationException("Could not find a config folder.");
-            }
-
-            var configPath = $"{configFolder}/config.json"; 
-
-            if (!File.Exists(configPath))
-            {
-                throw new InvalidOperationException($"No config found in config folder {configFolder}");
+                throw new InvalidOperationException($"No config found");
             }
 
             Config config = default;

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -10,5 +10,6 @@ namespace MaraBot.Core
         [JsonConverter(typeof(OptionsConverter))] public Dictionary<string, string> Options;
         public string Author;
         public string Description;
+        public int Weight;
     }
 }

--- a/MaraBot/Core/RandomUtils.cs
+++ b/MaraBot/Core/RandomUtils.cs
@@ -7,18 +7,29 @@ namespace MaraBot.Core
     {
         static Random s_TimeBasedRandom = new Random(DateTime.Now.GetHashCode());
         static DateTime s_FirstWeek = new DateTime(2021, 08, 19, 20, 0, 0);
+
+        public static int GetRandomIndex(int minIndex, int maxIndex)
+        {
+            return s_TimeBasedRandom.Next(minIndex, maxIndex);
+        }
         
         public static string GetRandomSeed()
         {
             return GetSeed(s_TimeBasedRandom);
         }
 
-        public static string GetWeeklySeed(int seedMultiplier)
+        public static int GetWeekNumber()
         {
             var elapsed = DateTime.Now.Subtract(s_FirstWeek);
             var elapsedWeeks = elapsed.Days / 7;
 
-            var seed = elapsedWeeks * seedMultiplier;
+            return elapsedWeeks;
+        }
+
+        public static string GetWeeklySeed(int seedMultiplier)
+        {
+            var weekNumber = GetWeekNumber();
+            var seed = weekNumber * seedMultiplier;
             
             var random = new Random(seed);
             return GetSeed(random);

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MaraBot.Core
+{
+    public class Weekly
+    {
+        public int WeekNumber;
+        public string PresetName;
+        public string Seed;
+
+        public static Weekly Invalid => new Weekly
+        {
+            WeekNumber = -1,
+            PresetName = String.Empty,
+            Seed = String.Empty
+        };
+        
+        public static Weekly Generate(IReadOnlyDictionary<string, Preset> presets)
+        {
+            var weekNumber = RandomUtils.GetWeekNumber();
+            var seed = RandomUtils.GetRandomSeed();
+
+            var weeklyPresets = presets.Where(preset => preset.Value.Weight > 0);
+            var totalWeight = weeklyPresets.Sum(preset => preset.Value.Weight);
+
+            if (totalWeight == 0)
+                return Weekly.Invalid;
+            
+            var index = RandomUtils.GetRandomIndex(0, totalWeight - 1);
+
+            var presetName = String.Empty;
+            
+            var sum = 0;
+            foreach (var preset in weeklyPresets)
+            {
+                sum += preset.Value.Weight;
+                if (sum > index)
+                {
+                    presetName = preset.Key;
+                    break;
+                }
+            }
+
+            return new Weekly
+            {
+                WeekNumber = weekNumber,
+                PresetName = presetName,
+                Seed = seed
+            };
+        }
+    }
+}

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -9,14 +9,16 @@ namespace MaraBot.Core
         public int WeekNumber;
         public string PresetName;
         public string Seed;
+        public Dictionary<string, TimeSpan> Leaderboard;
 
         public static Weekly Invalid => new Weekly
         {
             WeekNumber = -1,
             PresetName = String.Empty,
-            Seed = String.Empty
+            Seed = String.Empty,
+            Leaderboard = null
         };
-        
+
         public static Weekly Generate(IReadOnlyDictionary<string, Preset> presets)
         {
             var weekNumber = RandomUtils.GetWeekNumber();
@@ -27,11 +29,11 @@ namespace MaraBot.Core
 
             if (totalWeight == 0)
                 return Weekly.Invalid;
-            
+
             var index = RandomUtils.GetRandomIndex(0, totalWeight - 1);
 
             var presetName = String.Empty;
-            
+
             var sum = 0;
             foreach (var preset in weeklyPresets)
             {
@@ -47,7 +49,8 @@ namespace MaraBot.Core
             {
                 WeekNumber = weekNumber,
                 PresetName = presetName,
-                Seed = seed
+                Seed = seed,
+                Leaderboard = new Dictionary<string, TimeSpan>()
             };
         }
     }

--- a/MaraBot/Core/WeeklyIO.cs
+++ b/MaraBot/Core/WeeklyIO.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace MaraBot.Core
+{
+    public class WeeklyIO
+    {
+        private static readonly string k_WeeklyFolder = "$HOME/marabot";
+
+        public static void StoreWeekly(Weekly weekly)
+        {
+            var homeFolder =
+                (Environment.OSVersion.Platform == PlatformID.Unix ||
+                 Environment.OSVersion.Platform == PlatformID.MacOSX)
+                    ? Environment.GetEnvironmentVariable("HOME")
+                    : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
+
+            var weeklyFolder = k_WeeklyFolder.Replace("$HOME", homeFolder);
+            if (!Directory.Exists(weeklyFolder))
+                Directory.CreateDirectory(weeklyFolder);
+            
+            var weeklyPath = weeklyFolder + "/weekly.json";
+           
+            // TODO do this async...
+            using (StreamWriter w = new StreamWriter(weeklyPath))
+            {
+                var json = JsonConvert.SerializeObject(weekly);
+                w.Write(json);
+            }
+        }
+        
+        public static Weekly LoadWeekly()
+        {
+            var homeFolder =
+                (Environment.OSVersion.Platform == PlatformID.Unix ||
+                 Environment.OSVersion.Platform == PlatformID.MacOSX)
+                    ? Environment.GetEnvironmentVariable("HOME")
+                    : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
+            
+            var weeklyPath = k_WeeklyFolder.Replace("$HOME", homeFolder) + "/weekly.json";
+
+            var weekly = Weekly.Invalid;
+            if (String.IsNullOrEmpty(weeklyPath))
+            {
+                return weekly;
+            }
+            
+            using (StreamReader r = new StreamReader(weeklyPath))
+            {
+                var json = r.ReadToEnd();
+                weekly = JsonConvert.DeserializeObject<Weekly>(json);
+            }
+           
+            return weekly; 
+        }
+    }
+}

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -14,10 +14,10 @@ namespace MaraBot.Messages
     {
         const int kMinNumberOfElementsPerColumn = 4;
         const int kMaxNumberOfColumns = 3;
-       
+
         public const string kValidCommandEmoji = ":white_check_mark:";
         public const string kInvalidCommandEmoji = ":no_entry_sign:";
-        
+
         public static async Task Race(CommandContext ctx, Preset preset, string seed)
         {
             var embed = new DiscordEmbedBuilder
@@ -26,21 +26,21 @@ namespace MaraBot.Messages
                 Color = DiscordColor.Red,
                 Footer = new DiscordEmbedBuilder.EmbedFooter
                 {
-                    Text = "Generated" 
+                    Text = "Generated"
                 },
                 Timestamp = DateTime.Now
             };
 
-            var rawOptionsString = string.Join(" ", 
+            var rawOptionsString = string.Join(" ",
                 preset.Options.Select(kvp => $"{kvp.Key}={kvp.Value}")
             );
-            
+
             embed
                 .AddField(preset.Name, preset.Description)
                 .AddField("Seed", seed)
                 .AddOptionsToEmbed(preset)
                 .AddField("Raw Options", Formatter.BlockCode(rawOptionsString));
-            
+
             var mainBuilder = new DiscordMessageBuilder()
                .AddEmbed(embed);
 
@@ -58,20 +58,20 @@ namespace MaraBot.Messages
             string presetKeys = String.Empty;
             string presetNames = String.Empty;
             string presetDescriptions = String.Empty;
-            
+
             foreach (var preset in presets)
             {
                 presetKeys += $"**{preset.Key}**:\n";
                 presetNames += $"{preset.Value.Name}\n";
-                presetDescriptions += $"{preset.Value.Description}\n"; 
+                presetDescriptions += $"{preset.Value.Description}\n";
             }
-                
+
             embed
                 .AddField("Key", presetKeys, true)
                 .AddField("Name", presetNames, true)
                 .AddField("Description", presetDescriptions, true);
 
-            await ctx.RespondAsync(embed); 
+            await ctx.RespondAsync(embed);
         }
 
         public static async Task Preset(CommandContext ctx, Preset preset)
@@ -83,22 +83,22 @@ namespace MaraBot.Messages
             };
 
             embed
-                .AddField("Name", preset.Name)
+                .AddField("Week", preset.Name)
                 .AddField("Description", preset.Description)
                 .AddOptionsToEmbed(preset);
-            
-            await ctx.RespondAsync(embed); 
+
+            await ctx.RespondAsync(embed);
         }
 
         private static DiscordEmbedBuilder AddOptionsToEmbed(this DiscordEmbedBuilder embed, Preset preset)
         {
             int numberOfColumns = Math.Min((int)Math.Ceiling(preset.Options.Count / (float) kMinNumberOfElementsPerColumn), kMaxNumberOfColumns);
             int numberOfElementsPerColumn = (int)Math.Ceiling(preset.Options.Count / (float) numberOfColumns);
-            
+
             var optionStrings = new string[numberOfColumns];
             for (int i = 0; i < numberOfColumns; ++i)
                 optionStrings[i] = String.Empty;
-            
+
             int index = 0;
             int columnIndex = 0;
             foreach (var option in preset.Options)
@@ -122,6 +122,35 @@ namespace MaraBot.Messages
             }
 
             return embed;
+        }
+
+        public static async Task Leaderboard(CommandContext ctx, Weekly weekly)
+        {
+            var embed = new DiscordEmbedBuilder
+            {
+                Title = "Leaderboard",
+                Color = DiscordColor.Yellow
+            };
+
+            embed
+                .AddField("Weekly Seed", $"week #{weekly.WeekNumber}");
+
+            var sortedLeaderboard = weekly.Leaderboard
+                .OrderBy(kvp => kvp.Value);
+
+            var userStrings = String.Empty;
+            var timeStrings = String.Empty;
+
+            foreach (var entry in sortedLeaderboard)
+            {
+                userStrings += $"{entry.Key}\n";
+                timeStrings += $"{entry.Value}\n";
+            }
+
+            embed.AddField("User", userStrings, true);
+            embed.AddField("Time", timeStrings, true);
+
+            await ctx.RespondAsync(embed);
         }
     }
 }

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace MaraBot
 {
     using Core;
-    
+
     internal class Program
     {
         public static void Main(string[] args)
@@ -20,19 +20,19 @@ namespace MaraBot
             var config = ConfigIO.LoadConfig();
             var presets = PresetIO.LoadPresets();
             var weekly = WeeklyIO.LoadWeekly();
-            
+
             var discord = new DiscordShardedClient(new DiscordConfiguration()
             {
                 Token = config.Token,
                 TokenType = TokenType.Bot,
-                Intents = DiscordIntents.AllUnprivileged     
+                Intents = DiscordIntents.AllUnprivileged
             });
-           
+
             var services = new ServiceCollection()
                 .AddSingleton<IReadOnlyDictionary<string, Preset>>(_ => presets)
                 .AddSingleton(weekly)
                 .BuildServiceProvider();
-            
+
             var commands = await discord.UseCommandsNextAsync(new CommandsNextConfiguration()
             {
                 StringPrefixes = new[] { config.Prefix },
@@ -43,9 +43,11 @@ namespace MaraBot
             commands.RegisterCommands<Commands.PresetCommandModule>();
             commands.RegisterCommands<Commands.RaceCommandModule>();
             commands.RegisterCommands<Commands.WeeklyCommandModule>();
-            
+            commands.RegisterCommands<Commands.CompletedCommandModule>();
+            commands.RegisterCommands<Commands.LeaderboardCommandModule>();
+
             await discord.StartAsync();
             await Task.Delay(-1);
-        }   
+        }
     }
 }

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -19,6 +19,7 @@ namespace MaraBot
         {
             var config = ConfigIO.LoadConfig();
             var presets = PresetIO.LoadPresets();
+            var weekly = WeeklyIO.LoadWeekly();
             
             var discord = new DiscordShardedClient(new DiscordConfiguration()
             {
@@ -28,19 +29,20 @@ namespace MaraBot
             });
            
             var services = new ServiceCollection()
-                .AddSingleton<IWeeklyConfig>(_ => config)
                 .AddSingleton<IReadOnlyDictionary<string, Preset>>(_ => presets)
+                .AddSingleton(weekly)
                 .BuildServiceProvider();
             
             var commands = await discord.UseCommandsNextAsync(new CommandsNextConfiguration()
             {
-                StringPrefixes = new[] { "!" },
+                StringPrefixes = new[] { config.Prefix },
                 Services = services
             });
 
             commands.RegisterCommands<Commands.PresetsCommandModule>();
             commands.RegisterCommands<Commands.PresetCommandModule>();
             commands.RegisterCommands<Commands.RaceCommandModule>();
+            commands.RegisterCommands<Commands.WeeklyCommandModule>();
             
             await discord.StartAsync();
             await Task.Delay(-1);

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,0 @@
-{
-  "token": "my-token-goes-here",
-  "weeklySeed": 1234567
-}

--- a/config/config_template.json
+++ b/config/config_template.json
@@ -1,0 +1,4 @@
+{
+  "prefix": "!",
+  "token": "my-token-goes-here"
+}

--- a/presets/kinda-hard.json
+++ b/presets/kinda-hard.json
@@ -16,5 +16,6 @@
     }
   ],
   "author": "CrashTestGenius",
-  "description": "Open mode - Kinda hard"
+  "description": "Open mode - Kinda hard",
+  "weight": 2
 }

--- a/presets/vanilla-beast.json
+++ b/presets/vanilla-beast.json
@@ -13,5 +13,6 @@
     }
   ],
   "author": "Menblock",
-  "description": "Open mode - Mana Beast is buff" 
+  "description": "Open mode - Mana Beast is buff",
+  "weight": 2
 }


### PR DESCRIPTION
The `!weekly` command will
- Check with currently loaded weekly if the current week matches stored weekly.
- Generate a new weekly if week number doesn't match (random seed and random preset based on preset weight values).
- Store the weekly configuration to disk to make sure this is not lost (if bot needs to restart).
- Display the race settings to user.

Also added `!completed` and `!leaderboard` commands to go along with the weekly.
- `!completed` will add your username and associated time span to the leaderboard and also display the leaderboard.
- Upon calling completed, the bot will also write back the weekly config to file to ensure leaderboard persists throughout the weekly.
- `!leaderboard` will display the leaderboard.