### PR TITLE
Made weekly command use actual time the weekly was generated at

### DIFF
--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -42,7 +42,7 @@ namespace MaraBot.Commands
             }
 
             var preset = Presets[Weekly.PresetName];
-            await Display.Race(ctx, preset, Weekly.Seed, Weekly.GeneratedAt);
+            await Display.Race(ctx, preset, Weekly.Seed, Weekly.Timestamp);
 
             var successEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);
             await ctx.Message.CreateReactionAsync(successEmoji);

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -42,7 +42,7 @@ namespace MaraBot.Commands
             }
 
             var preset = Presets[Weekly.PresetName];
-            await Display.Race(ctx, preset, Weekly.Seed);
+            await Display.Race(ctx, preset, Weekly.Seed, Weekly.GeneratedAt);
 
             var successEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);
             await ctx.Message.CreateReactionAsync(successEmoji);

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -10,13 +10,15 @@ namespace MaraBot.Core
         public string PresetName;
         public string Seed;
         public Dictionary<string, TimeSpan> Leaderboard;
+        public DateTime GeneratedAt;
 
         public static Weekly Invalid => new Weekly
         {
             WeekNumber = -1,
             PresetName = String.Empty,
             Seed = String.Empty,
-            Leaderboard = null
+            Leaderboard = null,
+            GeneratedAt = DateTime.MinValue
         };
 
         public static Weekly Generate(IReadOnlyDictionary<string, Preset> presets)
@@ -50,7 +52,8 @@ namespace MaraBot.Core
                 WeekNumber = weekNumber,
                 PresetName = presetName,
                 Seed = seed,
-                Leaderboard = new Dictionary<string, TimeSpan>()
+                Leaderboard = new Dictionary<string, TimeSpan>(),
+                GeneratedAt = DateTime.Now
             };
         }
     }

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -10,7 +10,7 @@ namespace MaraBot.Core
         public string PresetName;
         public string Seed;
         public Dictionary<string, TimeSpan> Leaderboard;
-        public DateTime GeneratedAt;
+        public DateTime Timestamp;
 
         public static Weekly Invalid => new Weekly
         {
@@ -18,7 +18,7 @@ namespace MaraBot.Core
             PresetName = String.Empty,
             Seed = String.Empty,
             Leaderboard = null,
-            GeneratedAt = DateTime.MinValue
+            Timestamp = DateTime.MinValue
         };
 
         public static Weekly Generate(IReadOnlyDictionary<string, Preset> presets)
@@ -53,7 +53,7 @@ namespace MaraBot.Core
                 PresetName = presetName,
                 Seed = seed,
                 Leaderboard = new Dictionary<string, TimeSpan>(),
-                GeneratedAt = DateTime.Now
+                Timestamp = DateTime.Now
             };
         }
     }

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -22,7 +22,7 @@ namespace MaraBot.Messages
         {
             await Race(ctx, preset, seed, DateTime.Now);
         }
-        public static async Task Race(CommandContext ctx, Preset preset, string seed, DateTime generatedAt)
+        public static async Task Race(CommandContext ctx, Preset preset, string seed, DateTime timestamp)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -32,7 +32,7 @@ namespace MaraBot.Messages
                 {
                     Text = "Generated"
                 },
-                Timestamp = generatedAt
+                Timestamp = timestamp
             };
 
             var rawOptionsString = string.Join(" ",

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -20,6 +20,10 @@ namespace MaraBot.Messages
 
         public static async Task Race(CommandContext ctx, Preset preset, string seed)
         {
+            await Race(ctx, preset, seed, DateTime.Now);
+        }
+        public static async Task Race(CommandContext ctx, Preset preset, string seed, DateTime generatedAt)
+        {
             var embed = new DiscordEmbedBuilder
             {
                 Title = "Requested Seed",
@@ -28,7 +32,7 @@ namespace MaraBot.Messages
                 {
                     Text = "Generated"
                 },
-                Timestamp = DateTime.Now
+                Timestamp = generatedAt
             };
 
             var rawOptionsString = string.Join(" ",


### PR DESCRIPTION
If a already generated weekly was displayed using `!weekly`, the generated time would be the time the new message was sent.
This will probably confuse some people, thinking that the weekly re-generated.
Now the weekly command will use the time it was first generated on, on consecutive calls to `!weekly`.