### PR TITLE
Added more options and added OptionType enum

### DIFF
--- a/MaraBot/Core/Option.cs
+++ b/MaraBot/Core/Option.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace MaraBot.Core
 {
@@ -18,6 +19,15 @@ namespace MaraBot.Core
     }
 
     /// <summary>
+    /// Type of value an Option has.
+    /// </summary>
+    public enum OptionType
+    {
+        Enum, // Select one value from Values
+        List  // Select multiple values from Values, separated by a comma
+    }
+
+    /// <summary>
     /// Information about a randomizer option.
     /// </summary>
     public struct Option
@@ -33,6 +43,12 @@ namespace MaraBot.Core
         public readonly Mode Mode;
 
         /// <summary>
+        /// Type of value it supports.
+        /// </summary>
+        [DefaultValue(OptionType.Enum)]
+        public readonly OptionType Type;
+
+        /// <summary>
         /// Possible values the option can have in the options JSON/string,
         /// together with the display name as seen in the randomizer.
         /// Default values will not be in this dictionary,
@@ -43,11 +59,12 @@ namespace MaraBot.Core
         /// <summary>
         /// Create an Option with specified properties.
         /// </summary>
-        public Option( string name, Mode mode, IDictionary<string, string> values )
+        public Option(string name, Mode mode, OptionType type, IDictionary<string, string> values)
         {
             Name   = name  ;
             Mode   = mode  ;
             Values = values;
+            Type   = type  ;
         }
 
         /// <summary>
@@ -81,6 +98,15 @@ namespace MaraBot.Core
                 case "chaos"      : return Mode.Chaos      ;
                 default           : return Mode.Other      ;
             }
+        }
+
+        /// <summary>
+        /// Transform a string list of values (OptionType.List) into a List.
+        /// </summary>
+        public static List<string> ParseList(string values) {
+            var list = new List<string>(values.Split(','));
+            list.RemoveAll(s => s == "");
+            return list;
         }
     }
 }

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -58,15 +58,28 @@ namespace MaraBot.Core
             var list = new List<Tuple<Mode, string, string>>();
 
             foreach(var pair in Options) {
-                if(options.ContainsKey(pair.Key))
-                    list.Add(new Tuple<Mode, string, string>(
-                        options[pair.Key].Mode,
-                        options[pair.Key].Name,
-                        options[pair.Key].Values.ContainsKey(pair.Value)
-                                ? options[pair.Key].Values[pair.Value]
-                                : pair.Value
-                    ));
-                else
+                if(options.ContainsKey(pair.Key)) { // Found key
+                    var o = options[pair.Key];
+                    if(o.Type == OptionType.List) // List type
+                        list.Add(new Tuple<Mode, string, string>(
+                            o.Mode,
+                            o.Name,
+                            String.Join(", ", Option.ParseList(pair.Value).ConvertAll(
+                                v => o.Values.ContainsKey(v)
+                                        ? o.Values[v] // Value found
+                                        : v // No value found, use raw value
+                            ))
+                        ));
+                    else // Enum type
+                        list.Add(new Tuple<Mode, string, string>(
+                            o.Mode,
+                            o.Name,
+                            o.Values.ContainsKey(pair.Value)
+                                    ? o.Values[pair.Value] // Value found
+                                    : pair.Value // No value found, use raw value
+                        ));
+                }
+                else // No key found, use raw values
                     list.Add(new Tuple<Mode, string, string>(
                         Mode.Other,
                         pair.Key,

--- a/config/options.json
+++ b/config/options.json
@@ -849,5 +849,196 @@
     "values": {
       "yes": "Yes"
     }
+  },
+
+
+
+  "acDifficulty": {
+    "name": "Difficulty",
+    "mode": "AncientCave",
+    "values": {
+      "hard"      : "Hard",
+      "reallyhard": "Really hard",
+      "custom"    : "Custom"
+    }
+  },
+  "acDialogue": {
+    "name": "NPC Dialogue",
+    "mode": "AncientCave",
+    "values": {
+      "demetri": "Demetri Martin"
+    }
+  },
+  "acFilter": {
+    "name": "Dialogue language filter",
+    "mode": "AncientCave",
+    "values": {
+      "yes": "Yes"
+    }
+  },
+  "acMusic": {
+    "name": "Random music",
+    "mode": "AncientCave",
+    "values": {
+      "no": "No"
+    }
+  },
+  "acBoy": {
+    "name": "Boy",
+    "mode": "AncientCave",
+    "values": {
+      "no": "No"
+    }
+  },
+  "acGirl": {
+    "name": "Girl",
+    "mode": "AncientCave",
+    "values": {
+      "no": "No"
+    }
+  },
+  "acSprite": {
+    "name": "Sprite",
+    "mode": "AncientCave",
+    "values": {
+      "no": "No"
+    }
+  },
+  "acLength": {
+    "name": "Length",
+    "mode": "AncientCave",
+    "values": {
+      "short": "Short (8 Floors)",
+      "long" : "Long (24 Floors)"
+    }
+  },
+  "acBosses": {
+    "name": "Bosses",
+    "mode": "AncientCave",
+    "values": {
+      "every": "Every floor",
+      "final": "Final only"
+    }
+  },
+  "acBiomeTypes": {
+    "name": "Floor Types",
+    "mode": "AncientCave",
+    "type": "List",
+    "values": {
+      "forest"          : "Forest",
+      "island"          : "Island",
+      "ruins"           : "Ruins",
+      "cave"            : "Cave",
+      "manafortinterior": "Manafort Interior"
+    }
+  },
+
+
+
+  "brDifficulty": {
+    "name": "Difficulty",
+    "mode": "BossRush",
+    "values": {
+      "hard"      : "Hard",
+      "reallyhard": "Really hard",
+      "custom"    : "Custom"
+    }
+  },
+  "brBoy": {
+    "name": "Boy",
+    "mode": "BossRush",
+    "values": {
+      "no": "No"
+    }
+  },
+  "brGirl": {
+    "name": "Girl",
+    "mode": "BossRush",
+    "values": {
+      "no": "No"
+    }
+  },
+  "brSprite": {
+    "name": "Sprite",
+    "mode": "BossRush",
+    "values": {
+      "no": "No"
+    }
+  },
+  "brLimitMpAbsorb": {
+    "name": "Limit MP Absorb",
+    "mode": "BossRush",
+    "values": {
+      "no": "No"
+    }
+  },
+
+
+
+  "chDifficulty": {
+    "name": "Difficulty",
+    "mode": "Chaos",
+    "values": {
+      "hard"      : "Hard",
+      "reallyhard": "Really hard",
+      "custom"    : "Custom"
+    }
+  },
+  "chBoy": {
+    "name": "Boy",
+    "mode": "Chaos",
+    "values": {
+      "no": "No"
+    }
+  },
+  "chGirl": {
+    "name": "Girl",
+    "mode": "Chaos",
+    "values": {
+      "no": "No"
+    }
+  },
+  "chSprite": {
+    "name": "Sprite",
+    "mode": "Chaos",
+    "values": {
+      "no": "No"
+    }
+  },
+  "chTODO1": {
+    "name": "Length",
+    "mode": "Chaos",
+    "values": {
+      "todo": "TODO"
+    }
+  },
+  "chTODO2": {
+    "name": "Bosses",
+    "mode": "Chaos",
+    "values": {
+      "todo": "TODO"
+    }
+  },
+  "chMapColors": {
+    "name": "Color randomization",
+    "mode": "Chaos",
+    "values": {
+      "none"      : "None",
+      "ridiculous": "Ridiculous"
+    }
+  },
+  "chHealSpellsFirst": {
+    "name": "Prioritize heal spells",
+    "mode": "Chaos",
+    "values": {
+      "no": "No"
+    }
+  },
+  "chEasyEarlyFloors": {
+    "name": "Safer early floors",
+    "mode": "Chaos",
+    "values": {
+      "no": "No"
+    }
   }
 }


### PR DESCRIPTION
Final two options are chaos mode options, but we need to wait until these options function before I can add them.
If this pull request is approved and merged, I will add those options (when they are fixed) in a new branch.
Added an `OptionType` enum to add support for the one option in the randomizer that uses a list of values.
Because of the rarity of a different `OptionType` than `OptionType.Enum`, I have made `OptionType.Enum` the default value, to reduce the `options.json` file size.