### PR TITLE
Added support for custom races.

### DIFF
--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
@@ -40,7 +41,7 @@ namespace MaraBot.Commands
                     "Insufficient privileges to create a custom race.\n" +
                     "This command is only available to the following roles:\n" +
                     String.Join(", ",guildRoles
-                        .Select(role => role.Value.Mention)
+                        .Select(role => Formatter.Bold(role.Value.Name))
                         ));
 
                 return false;

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using MaraBot.Core;
+using MaraBot.Messages;
+
+namespace MaraBot.Commands
+{
+    public class CustomRaceCommandModule : BaseCommandModule
+    {
+        public IReadOnlyDictionary<string, Option> Options { private get; set; }
+
+        [Command("custom")]
+        [Cooldown(15, 900, CooldownBucketType.User)]
+        [RequireRoles(RoleCheckMode.Any, new [] {"bot overlord", "organizes races"})]
+        [RequireGuild]
+        public async Task Execute(CommandContext ctx)
+        {
+            var success = LaunchCustomRace(ctx);
+
+            var emoji = DiscordEmoji.FromName(ctx.Client, await success ? Display.kValidCommandEmoji : Display.kInvalidCommandEmoji);
+            await ctx.Message.CreateReactionAsync(emoji);
+        }
+
+        private async Task<bool> LaunchCustomRace(CommandContext ctx)
+        {
+            if (ctx.Message.Attachments == null || ctx.Message.Attachments.Count != 1)
+            {
+                await ctx.RespondAsync("No attachment for custom race. You must supply a valid json file.");
+                return false;
+            }
+
+            var attachment = ctx.Message.Attachments[0];
+            var url = attachment.Url;
+
+            var request = WebRequest.Create(url);
+            var responseTask = request.GetResponseAsync();
+
+            if (Path.GetExtension(attachment.FileName).ToLower() != ".json")
+            {
+                await ctx.RespondAsync("Invalid json file.");
+                return false;
+            }
+
+            var response = await responseTask;
+            var dataStream = response.GetResponseStream();
+
+            using (StreamReader r = new StreamReader(dataStream))
+            {
+                var jsonContent = await r.ReadToEndAsync();
+                var preset = PresetIO.LoadPreset(jsonContent, Options);
+                if (preset == null)
+                {
+                    await ctx.RespondAsync($"Could not parse custom json preset. Please supply a valid json file.");
+                    return false;
+                }
+
+                var seed = RandomUtils.GetRandomSeed();
+                await Display.Race(ctx, preset, seed);
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -22,7 +22,7 @@ namespace MaraBot.Commands
             var weekly = Weekly;
             if (weekNumber != currentWeek)
             {
-                weekly = WeeklyIO.LoadWeekly($"weekly.{weekNumber}.json");
+                weekly = await WeeklyIO.LoadWeekly($"weekly.{weekNumber}.json");
             }
 
             if (weekly.Leaderboard == null || weekly.Leaderboard.Count == 0)

--- a/MaraBot/Commands/RaceCommandModule.cs
+++ b/MaraBot/Commands/RaceCommandModule.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -8,33 +10,78 @@ namespace MaraBot.Commands
 {
     using Core;
     using Messages;
-    
+
     public class RaceCommandModule : BaseCommandModule
     {
         public IReadOnlyDictionary<string, Preset> Presets { private get; set; }
+        public IReadOnlyDictionary<string, Option> Options { private get; set; }
 
         [Command("race")]
         [Cooldown(15, 900, CooldownBucketType.User)]
         [RequireGuild]
         public async Task Execute(CommandContext ctx, string presetName)
         {
+            var success = (presetName == "custom") ?
+                LaunchCustomRace(ctx) :
+                LaunchPresetRace(ctx, presetName);
+
+            var emoji = DiscordEmoji.FromName(ctx.Client, await success ? Display.kValidCommandEmoji : Display.kInvalidCommandEmoji);
+            await ctx.Message.CreateReactionAsync(emoji);
+        }
+
+        public async Task<bool> LaunchCustomRace(CommandContext ctx)
+        {
+            if (ctx.Message.Attachments == null || ctx.Message.Attachments.Count == 0)
+            {
+                await ctx.RespondAsync("No attachment for custom race. You must supply a valid json file.");
+                return false;
+            }
+
+            var attachment = ctx.Message.Attachments[0];
+            var url = attachment.Url;
+
+            var request = WebRequest.Create(url);
+            var responseTask = request.GetResponseAsync();
+
+            if (Path.GetExtension(attachment.FileName).ToLower() != ".json")
+            {
+                await ctx.RespondAsync("Invalid json file.");
+                return false;
+            }
+
+            var response = await responseTask;
+            var dataStream = response.GetResponseStream();
+
+            using (StreamReader r = new StreamReader(dataStream))
+            {
+                var jsonContent = await r.ReadToEndAsync();
+                var preset = PresetIO.LoadPreset(jsonContent, Options);
+                if (preset == null)
+                {
+                    await ctx.RespondAsync($"Could not parse custom json preset. Please supply a valid json file.");
+                    return false;
+                }
+
+                var seed = RandomUtils.GetRandomSeed();
+                await Display.Race(ctx, preset, seed);
+            }
+
+            return true;
+        }
+
+        public async Task<bool> LaunchPresetRace(CommandContext ctx, string presetName)
+        {
             if (!Presets.ContainsKey(presetName))
             {
                 await ctx.RespondAsync($"{presetName} is not a a valid preset");
-                
-                var invalidEmoji = DiscordEmoji.FromName(ctx.Client, Display.kInvalidCommandEmoji);
-                await ctx.Message.CreateReactionAsync(invalidEmoji);
-                
-                return; 
+                return false;
             }
 
-            var preset = Presets[presetName];
             var seed = RandomUtils.GetRandomSeed();
+            var preset = Presets[presetName];
 
             await Display.Race(ctx, preset, seed);
-            
-            var successEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);
-            await ctx.Message.CreateReactionAsync(successEmoji);
+            return true;
         }
     }
 }

--- a/MaraBot/Commands/RaceCommandModule.cs
+++ b/MaraBot/Commands/RaceCommandModule.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -14,59 +12,16 @@ namespace MaraBot.Commands
     public class RaceCommandModule : BaseCommandModule
     {
         public IReadOnlyDictionary<string, Preset> Presets { private get; set; }
-        public IReadOnlyDictionary<string, Option> Options { private get; set; }
 
         [Command("race")]
         [Cooldown(15, 900, CooldownBucketType.User)]
         [RequireGuild]
         public async Task Execute(CommandContext ctx, string presetName)
         {
-            var success = (presetName == "custom") ?
-                LaunchCustomRace(ctx) :
-                LaunchPresetRace(ctx, presetName);
+            var success = LaunchPresetRace(ctx, presetName);
 
             var emoji = DiscordEmoji.FromName(ctx.Client, await success ? Display.kValidCommandEmoji : Display.kInvalidCommandEmoji);
             await ctx.Message.CreateReactionAsync(emoji);
-        }
-
-        public async Task<bool> LaunchCustomRace(CommandContext ctx)
-        {
-            if (ctx.Message.Attachments == null || ctx.Message.Attachments.Count == 0)
-            {
-                await ctx.RespondAsync("No attachment for custom race. You must supply a valid json file.");
-                return false;
-            }
-
-            var attachment = ctx.Message.Attachments[0];
-            var url = attachment.Url;
-
-            var request = WebRequest.Create(url);
-            var responseTask = request.GetResponseAsync();
-
-            if (Path.GetExtension(attachment.FileName).ToLower() != ".json")
-            {
-                await ctx.RespondAsync("Invalid json file.");
-                return false;
-            }
-
-            var response = await responseTask;
-            var dataStream = response.GetResponseStream();
-
-            using (StreamReader r = new StreamReader(dataStream))
-            {
-                var jsonContent = await r.ReadToEndAsync();
-                var preset = PresetIO.LoadPreset(jsonContent, Options);
-                if (preset == null)
-                {
-                    await ctx.RespondAsync($"Could not parse custom json preset. Please supply a valid json file.");
-                    return false;
-                }
-
-                var seed = RandomUtils.GetRandomSeed();
-                await Display.Race(ctx, preset, seed);
-            }
-
-            return true;
         }
 
         public async Task<bool> LaunchPresetRace(CommandContext ctx, string presetName)

--- a/MaraBot/Core/Config.cs
+++ b/MaraBot/Core/Config.cs
@@ -1,9 +1,23 @@
 
+using System.Collections.Generic;
+
 namespace MaraBot.Core
 {
-    public struct Config
+    public interface IConfig
+    {
+        public string Prefix { get; }
+        public string Token { get; }
+        public IReadOnlyCollection<string> OrganizerRoles { get; }
+    }
+
+    public class Config : IConfig
     {
         public string Prefix;
         public string Token;
+        public string[] OrganizerRoles;
+
+        string IConfig.Prefix => Prefix;
+        string IConfig.Token => Token;
+        IReadOnlyCollection<string> IConfig.OrganizerRoles => OrganizerRoles;
     }
 }

--- a/MaraBot/Core/ConfigIO.cs
+++ b/MaraBot/Core/ConfigIO.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MaraBot.Core
@@ -17,15 +18,15 @@ namespace MaraBot.Core
             "$HOME/marabot/config",
             "$HOME/marabot"
         };
-        
-        public static Config LoadConfig()
+
+        public static async Task<Config> LoadConfig()
         {
             var homeFolder =
                 (Environment.OSVersion.Platform == PlatformID.Unix ||
                  Environment.OSVersion.Platform == PlatformID.MacOSX)
                     ? Environment.GetEnvironmentVariable("HOME")
                     : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
-            
+
             var configPath = k_ConfigFolders
                 .Select(path => path.Replace("$HOME", homeFolder) + "/config.json")
                 .FirstOrDefault(path => File.Exists(path));
@@ -35,14 +36,11 @@ namespace MaraBot.Core
                 throw new InvalidOperationException($"No config found");
             }
 
-            Config config = default;
             using (StreamReader r = new StreamReader(configPath))
             {
-                var json = r.ReadToEnd();
-                config = JsonConvert.DeserializeObject<Config>(json);
+                var json = await r.ReadToEndAsync();
+                return JsonConvert.DeserializeObject<Config>(json);
             }
-
-            return config; 
         }
     }
 }

--- a/MaraBot/Core/OptionsIO.cs
+++ b/MaraBot/Core/OptionsIO.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MaraBot.Core
@@ -15,7 +16,7 @@ namespace MaraBot.Core
             "../../../../config",
         };
 
-        public static Dictionary<string, Option> LoadOptions()
+        public static async Task<Dictionary<string, Option>> LoadOptions()
         {
             var optionsPath = k_ConfigFolders
                 .Select(path => $"{path}/options.json")
@@ -28,7 +29,7 @@ namespace MaraBot.Core
 
             using (StreamReader r = new StreamReader(optionsPath))
             {
-                var json = r.ReadToEnd();
+                var json = await r.ReadToEndAsync();
                 return JsonConvert.DeserializeObject<Dictionary<string, Option>>(json);
             }
         }

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -53,7 +53,7 @@ namespace MaraBot.Core
         /// Parses the set of flags in Options, based on the options given,
         /// to populate the list of general, mode-specific and other options.
         /// </summary>
-        public void MakeDisplayable(Dictionary<string, Option> options)
+        public void MakeDisplayable(IReadOnlyDictionary<string, Option> options)
         {
             var list = new List<Tuple<Mode, string, string>>();
 

--- a/MaraBot/Core/WeeklyIO.cs
+++ b/MaraBot/Core/WeeklyIO.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MaraBot.Core
@@ -9,7 +10,7 @@ namespace MaraBot.Core
     {
         private static readonly string k_WeeklyFolder = "$HOME/marabot";
 
-        public static void StoreWeekly(Weekly weekly)
+        public static async void StoreWeekly(Weekly weekly)
         {
             var homeFolder =
                 (Environment.OSVersion.Platform == PlatformID.Unix ||
@@ -23,15 +24,14 @@ namespace MaraBot.Core
 
             var weeklyPath = weeklyFolder + "/weekly.json";
 
-            // TODO do this async...
             using (StreamWriter w = new StreamWriter(weeklyPath))
             {
                 var json = JsonConvert.SerializeObject(weekly);
-                w.Write(json);
+                await w.WriteAsync(json);
             }
         }
 
-        public static Weekly LoadWeekly()
+        public static async Task<Weekly> LoadWeekly()
         {
             var homeFolder =
                 (Environment.OSVersion.Platform == PlatformID.Unix ||
@@ -49,11 +49,9 @@ namespace MaraBot.Core
 
             using (StreamReader r = new StreamReader(weeklyPath))
             {
-                var json = r.ReadToEnd();
-                weekly = JsonConvert.DeserializeObject<Weekly>(json);
+                var json = await r.ReadToEndAsync();
+                return JsonConvert.DeserializeObject<Weekly>(json);
             }
-
-            return weekly;
         }
     }
 }

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -18,7 +18,7 @@ namespace MaraBot.Messages
         public const string kValidCommandEmoji = ":white_check_mark:";
         public const string kInvalidCommandEmoji = ":no_entry_sign:";
 
-        public static async Task Race(CommandContext ctx, Preset preset, string seed)
+        public static Task Race(CommandContext ctx, Preset preset, string seed)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -44,10 +44,10 @@ namespace MaraBot.Messages
             var mainBuilder = new DiscordMessageBuilder()
                .AddEmbed(embed);
 
-            await ctx.RespondAsync(mainBuilder);
+            return ctx.RespondAsync(mainBuilder);
         }
 
-        public static async Task Presets(CommandContext ctx, IReadOnlyDictionary<string, Preset> presets)
+        public static Task Presets(CommandContext ctx, IReadOnlyDictionary<string, Preset> presets)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -71,10 +71,10 @@ namespace MaraBot.Messages
                 .AddField("Name", presetNames, true)
                 .AddField("Description", presetDescriptions, true);
 
-            await ctx.RespondAsync(embed);
+            return ctx.RespondAsync(embed);
         }
 
-        public static async Task Preset(CommandContext ctx, Preset preset)
+        public static Task Preset(CommandContext ctx, Preset preset)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -89,7 +89,7 @@ namespace MaraBot.Messages
                 .AddField("Author", preset.Author)
                 .AddOptionsToEmbed(preset);
 
-            await ctx.RespondAsync(embed);
+            return ctx.RespondAsync(embed);
         }
 
         private static DiscordEmbedBuilder AddOptionDictionaryToEmbed(this DiscordEmbedBuilder embed, string title, Dictionary<string, string> options)
@@ -136,7 +136,7 @@ namespace MaraBot.Messages
             return embed;
         }
 
-        public static async Task Leaderboard(CommandContext ctx, Weekly weekly)
+        public static Task Leaderboard(CommandContext ctx, Weekly weekly)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -162,7 +162,7 @@ namespace MaraBot.Messages
             embed.AddField("User", userStrings, true);
             embed.AddField("Time", timeStrings, true);
 
-            await ctx.RespondAsync(embed);
+            return ctx.RespondAsync(embed);
         }
     }
 }

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -20,9 +20,10 @@ namespace MaraBot.Messages
 
         public static Task Race(CommandContext ctx, Preset preset, string seed)
         {
-            await Race(ctx, preset, seed, DateTime.Now);
+            return Race(ctx, preset, seed, DateTime.Now);
         }
-        public static async Task Race(CommandContext ctx, Preset preset, string seed, DateTime timestamp)
+
+        public static Task Race(CommandContext ctx, Preset preset, string seed, DateTime timestamp)
         {
             var embed = new DiscordEmbedBuilder
             {

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -39,6 +39,7 @@ namespace MaraBot
             var services = new ServiceCollection()
                 .AddSingleton<IReadOnlyDictionary<string, Preset>>(_ => presets)
                 .AddSingleton<IReadOnlyDictionary<string, Option>>(_ => options)
+                .AddSingleton<IConfig>(_ => config)
                 .AddSingleton(weekly)
                 .BuildServiceProvider();
 

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -19,10 +19,12 @@ namespace MaraBot
 
         static async Task MainAsync()
         {
-            var config = ConfigIO.LoadConfig();
-            var options = OptionsIO.LoadOptions();
-            var presets = PresetIO.LoadPresets(options);
-            var weekly = WeeklyIO.LoadWeekly();
+            var configTask = ConfigIO.LoadConfig();
+            var weeklyTask = WeeklyIO.LoadWeekly();
+            var options = await OptionsIO.LoadOptions();
+            var presetsTask = PresetIO.LoadPresets(options);
+
+            var config = await configTask;
 
             var discord = new DiscordShardedClient(new DiscordConfiguration()
             {
@@ -31,8 +33,12 @@ namespace MaraBot
                 Intents = DiscordIntents.AllUnprivileged
             });
 
+            var presets = await presetsTask;
+            var weekly = await weeklyTask;
+
             var services = new ServiceCollection()
                 .AddSingleton<IReadOnlyDictionary<string, Preset>>(_ => presets)
+                .AddSingleton<IReadOnlyDictionary<string, Option>>(_ => options)
                 .AddSingleton(weekly)
                 .BuildServiceProvider();
 

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -51,6 +51,7 @@ namespace MaraBot
             commands.RegisterCommands<Commands.PresetsCommandModule>();
             commands.RegisterCommands<Commands.PresetCommandModule>();
             commands.RegisterCommands<Commands.RaceCommandModule>();
+            commands.RegisterCommands<Commands.CustomRaceCommandModule>();
             commands.RegisterCommands<Commands.CreatePresetCommandModule>();
             commands.RegisterCommands<Commands.WeeklyCommandModule>();
             commands.RegisterCommands<Commands.CompletedCommandModule>();

--- a/config/config_template.json
+++ b/config/config_template.json
@@ -1,4 +1,7 @@
 {
   "prefix": "!",
-  "token": "my-token-goes-here"
+  "token": "my-token-goes-here",
+  "organizerRoles": [
+    "organizes races"
+  ]
 }


### PR DESCRIPTION
To create a custom race, simply drag & drop a valid json file unto the racing channel and type in `$race custom` in the comments.

![Screen Shot 2021-09-01 at 12 21 26 AM](https://user-images.githubusercontent.com/70881002/131611402-15e6d249-18a1-4736-8fd2-9b5e54ba94e4.png)

The file uploaded to discord can be then read back in the discord command and we can create a live preset from it.

Seeing as this is streamed directly to memory and never saved to file, I don't see how this could be maliciously exploited, but I'm not an expert on security 😓 ...

Otherwise, this could be offered as an option for weekly races and would only be usable by trusted race planning users.