### PR TITLE
Reworked weekly, completed and leaderboard commands.

### DIFF
--- a/MaraBot/Commands/CompletedCommandModule.cs
+++ b/MaraBot/Commands/CompletedCommandModule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
@@ -16,16 +17,14 @@ namespace MaraBot.Commands
         [Command("done")]
         [Cooldown(2, 900, CooldownBucketType.User)]
         [RequireGuild]
+        [RequireBotPermissions(Permissions.ManageMessages)]
         public async Task Execute(CommandContext ctx, TimeSpan time)
         {
-            var weekNumber = RandomUtils.GetWeekNumber();
-            if (Weekly.WeekNumber != weekNumber)
-            {
-                await ctx.RespondAsync("No weekly seed generated for this week. Generate one using the weekly command first.");
+            // Delete user message to avoid spoilers.
+            // This requires access to ManagerMessages permissions.
+            await ctx.Message.DeleteAsync();
 
-                var invalidEmoji = DiscordEmoji.FromName(ctx.Client, Display.kInvalidCommandEmoji);
-                await ctx.Message.CreateReactionAsync(invalidEmoji);
-            }
+            await ctx.RespondAsync($"Adding {ctx.User.Mention} to the leaderboard!");
 
             var username = ctx.User.Username;
 
@@ -38,10 +37,7 @@ namespace MaraBot.Commands
                 Weekly.Leaderboard.Add(username, time);
 
             WeeklyIO.StoreWeekly(Weekly);
-            await Display.Leaderboard(ctx, Weekly);
-
-            var validEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);
-            await ctx.Message.CreateReactionAsync(validEmoji);
+            await Display.Leaderboard(ctx, Weekly, true);
         }
     }
 }

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -14,18 +14,28 @@ namespace MaraBot.Commands
         [Command("leaderboard")]
         [Cooldown(5, 900, CooldownBucketType.User)]
         [RequireGuild]
-        public async Task Execute(CommandContext ctx)
+        public async Task Execute(CommandContext ctx, int weekNumber = -1)
         {
-            var weekNumber = RandomUtils.GetWeekNumber();
-            if (Weekly.WeekNumber != weekNumber)
+            var currentWeek = RandomUtils.GetWeekNumber();
+            weekNumber = weekNumber == -1 ? currentWeek : weekNumber;
+
+            var weekly = Weekly;
+            if (weekNumber != currentWeek)
             {
-                await ctx.RespondAsync("No weekly seed generated for this week. Generate one using the weekly command first.");
+                weekly = WeeklyIO.LoadWeekly($"weekly.{weekNumber}.json");
+            }
+
+            if (weekly.Leaderboard == null || weekly.Leaderboard.Count == 0)
+            {
+                await ctx.RespondAsync($"No leaderboard available for week {weekNumber}.");
 
                 var invalidEmoji = DiscordEmoji.FromName(ctx.Client, Display.kInvalidCommandEmoji);
                 await ctx.Message.CreateReactionAsync(invalidEmoji);
+
+                return;
             }
 
-            await Display.Leaderboard(ctx, Weekly);
+            await Display.Leaderboard(ctx, weekly, weekNumber == currentWeek);
 
             var validEmoji = DiscordEmoji.FromName(ctx.Client, Display.kValidCommandEmoji);
             await ctx.Message.CreateReactionAsync(validEmoji);

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -20,15 +20,6 @@ namespace MaraBot.Commands
         [RequireGuild]
         public async Task Execute(CommandContext ctx)
         {
-            var weekNumber = RandomUtils.GetWeekNumber();
-
-            // Generate a new weekly seed
-            if (Weekly.WeekNumber != weekNumber)
-            {
-                Weekly = Weekly.Generate(Presets);
-                WeeklyIO.StoreWeekly(Weekly);
-            }
-
             if (!Presets.ContainsKey(Weekly.PresetName) || Weekly.WeekNumber < 0)
             {
                 await ctx.RespondAsync(

--- a/MaraBot/Core/RandomUtils.cs
+++ b/MaraBot/Core/RandomUtils.cs
@@ -6,13 +6,13 @@ namespace MaraBot.Core
     public static class RandomUtils
     {
         static Random s_TimeBasedRandom = new Random(DateTime.Now.GetHashCode());
-        static DateTime s_FirstWeek = new DateTime(2021, 08, 19, 20, 0, 0);
+        static DateTime s_FirstWeek = new DateTime(2021, 08, 13, 0, 0, 0);
 
         public static int GetRandomIndex(int minIndex, int maxIndex)
         {
             return s_TimeBasedRandom.Next(minIndex, maxIndex);
         }
-        
+
         public static string GetRandomSeed()
         {
             return GetSeed(s_TimeBasedRandom);
@@ -20,7 +20,7 @@ namespace MaraBot.Core
 
         public static int GetWeekNumber()
         {
-            var elapsed = DateTime.Now.Subtract(s_FirstWeek);
+            var elapsed = DateTime.UtcNow.Subtract(s_FirstWeek);
             var elapsedWeeks = elapsed.Days / 7;
 
             return elapsedWeeks;
@@ -30,11 +30,11 @@ namespace MaraBot.Core
         {
             var weekNumber = GetWeekNumber();
             var seed = weekNumber * seedMultiplier;
-            
+
             var random = new Random(seed);
             return GetSeed(random);
         }
-       
+
         private static string GetSeed(Random randomGenerator)
         {
             byte[] buffer = new byte[8];

--- a/MaraBot/Core/WeeklyIO.cs
+++ b/MaraBot/Core/WeeklyIO.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using DSharpPlus;
 using Newtonsoft.Json;
 
 namespace MaraBot.Core
@@ -9,7 +10,7 @@ namespace MaraBot.Core
     {
         private static readonly string k_WeeklyFolder = "$HOME/marabot";
 
-        public static void StoreWeekly(Weekly weekly)
+        public static void StoreWeekly(Weekly weekly, string weeklyFilename = "weekly.json")
         {
             var homeFolder =
                 (Environment.OSVersion.Platform == PlatformID.Unix ||
@@ -21,17 +22,17 @@ namespace MaraBot.Core
             if (!Directory.Exists(weeklyFolder))
                 Directory.CreateDirectory(weeklyFolder);
 
-            var weeklyPath = weeklyFolder + "/weekly.json";
+            var weeklyPath = weeklyFolder + "/" + weeklyFilename;
 
             // TODO do this async...
             using (StreamWriter w = new StreamWriter(weeklyPath))
             {
-                var json = JsonConvert.SerializeObject(weekly);
+                var json = JsonConvert.SerializeObject(weekly, Formatting.Indented);
                 w.Write(json);
             }
         }
 
-        public static Weekly LoadWeekly()
+        public static Weekly LoadWeekly(string weeklyFilename = "weekly.json")
         {
             var homeFolder =
                 (Environment.OSVersion.Platform == PlatformID.Unix ||
@@ -39,7 +40,7 @@ namespace MaraBot.Core
                     ? Environment.GetEnvironmentVariable("HOME")
                     : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
 
-            var weeklyPath = k_WeeklyFolder.Replace("$HOME", homeFolder) + "/weekly.json";
+            var weeklyPath = k_WeeklyFolder.Replace("$HOME", homeFolder) + "/" + weeklyFilename;
 
             var weekly = Weekly.Invalid;
             if (!File.Exists(weeklyPath))


### PR DESCRIPTION
Tweaks to weeklies for upcoming races
- `!weekly` command no longer generate races, it reads back from the current race stored in `weekly.json`.
- `!leaderboard` takes an optional int parameter and will load a read-only weekly file to display a leaderboard for previous weeks.
- `!leaderboard` will display a spoiler free board for the current week's race. Names are not sorted and times are marked as spoilers.
- `!completed` will add the time to the leaderboard and erase the user's message (this requires ManageMessage permissions). It will then display a spoiler free leaderboard.
