### PR TITLE
Sample file to launch MaraBot as a service on linux.

### DIFF
--- a/linux/marabotd
+++ b/linux/marabotd
@@ -1,0 +1,64 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:          marabotd
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Start Mara Bot
+### END INIT INFO
+
+# Init and get environment variables
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+. /lib/lsb/init-functions
+
+[ -f /home/mara/.env ] && . /home/mara/.env
+[ -z "$PROJECT_PATH" ] && PROJECT_PATH=/home/mara/.marabot
+[ -z "$PROJECT_BIN" ] && PROJECT_BIN=MaraBot/bin/Release/netcoreapp3.1/MaraBot
+[ -z "$DOTNET_PATH" ] && DOTNET_PATH=/home/mara/.dotnet
+
+set -e
+
+# Functions
+start() {
+    cd "$PROJECT_PATH"
+    runuser -u mara "$DOTNET_PATH/dotnet" "$PROJECT_BIN" >> /var/log/MaraBot.log &
+}
+
+stop() {
+    killall "$DOTNET_PATH/dotnet"
+}
+
+restart() {
+    stop
+    start
+}
+
+
+
+# Carry out above functions when asked to by the system
+case "$1" in
+  start)
+    log_daemon_msg "Starting Mara Bot.."
+    start
+    log_end_msg 0
+    ;;
+  stop)
+    log_daemon_msg "Stopping Mara Bot.."
+    stop
+    log_end_msg 0
+    ;;
+  restart)
+    log_daemon_msg "Restarting Mara Bot.."
+    restart
+    log_end_msg 0
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
We can copy this file in /etc/init.d/ on a Debian compatible system.
Service can be registered using the following command:
>> `update-rc.d marabotd defaults`

Unsure if this will work on other distros...