### PR TITLE
Weekly spoiler roles/channel support

### DIFF
--- a/MaraBot/Commands/CreatePresetCommandModule.cs
+++ b/MaraBot/Commands/CreatePresetCommandModule.cs
@@ -25,9 +25,7 @@ namespace MaraBot.Commands
         [Description("Create a dummy preset file, with options if given.")]
         [Cooldown(5, 600, CooldownBucketType.User)]
         [RequireDirectMessage]
-        [RequirePermissions(
-            Permissions.SendMessages |
-            Permissions.AddReactions)]
+        [RequirePermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, [RemainingText] string optionString)
         {
             string[] optionValues = optionString == null ? new string[] { "key=value" } : optionString.Split(' ');

--- a/MaraBot/Commands/CreatePresetCommandModule.cs
+++ b/MaraBot/Commands/CreatePresetCommandModule.cs
@@ -25,6 +25,9 @@ namespace MaraBot.Commands
         [Description("Create a dummy preset file, with options if given.")]
         [Cooldown(5, 600, CooldownBucketType.User)]
         [RequireDirectMessage]
+        [RequirePermissions(
+            Permissions.SendMessages |
+            Permissions.AddReactions)]
         public async Task Execute(CommandContext ctx, [RemainingText] string optionString)
         {
             string[] optionValues = optionString == null ? new string[] { "key=value" } : optionString.Split(' ');

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -92,7 +92,7 @@ namespace MaraBot.Commands
                 }
 
                 var seed = RandomUtils.GetRandomSeed();
-                await ctx.RespondAsync(Display.RaceEmbed(ctx, preset, seed));
+                await ctx.RespondAsync(Display.RaceEmbed(preset, seed));
             }
 
             await CommandUtils.SendSuccessReaction(ctx);

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -92,7 +92,7 @@ namespace MaraBot.Commands
                 }
 
                 var seed = RandomUtils.GetRandomSeed();
-                await Display.RaceAsync(ctx, preset, seed);
+                await ctx.RespondAsync(Display.RaceEmbed(ctx, preset, seed));
             }
 
             await CommandUtils.SendSuccessReaction(ctx);

--- a/MaraBot/Commands/ForfeitCommandModule.cs
+++ b/MaraBot/Commands/ForfeitCommandModule.cs
@@ -13,10 +13,10 @@ namespace MaraBot.Commands
     using Messages;
 
     /// <summary>
-    /// Implements the completed command.
+    /// Implements the forfeit command.
     /// This command is used to add your time to the leaderboard.
     /// </summary>
-    public class CompletedCommandModule : BaseCommandModule
+    public class ForfeitCommandModule : BaseCommandModule
     {
         /// <summary>
         /// Weekly settings.
@@ -28,14 +28,14 @@ namespace MaraBot.Commands
         public IConfig Config { private get; set; }
 
         /// <summary>
-        /// Executes the completed command.
+        /// Executes the forfeit command.
         /// </summary>
         /// <param name="ctx">Command Context.</param>
         /// <param name="time">Elapsed time. Expecting HH:MM:SS format.</param>
         /// <returns>Returns an asynchronous task.</returns>
-        [Command("completed")]
-        [Aliases("done")]
-        [Description("Add your time to the leaderboard.")]
+        [Command("forfeit")]
+        [Aliases("forfeited")]
+        [Description("Forfeit the weekly.")]
         [Cooldown(2, 900, CooldownBucketType.User)]
         [RequireGuild]
         [RequirePermissions(
@@ -43,11 +43,10 @@ namespace MaraBot.Commands
             Permissions.ManageMessages |
             Permissions.ManageRoles |
             Permissions.AccessChannels)]
-        public async Task Execute(CommandContext ctx, TimeSpan time)
+        public async Task Execute(CommandContext ctx)
         {
             // Delete user message to avoid spoilers, if we can delete the message.
-            if (await CommandUtils.HasBotPermissions(ctx, Permissions.ManageMessages))
-                await ctx.Message.DeleteAsync();
+            await ctx.Message.DeleteAsync();
 
             // Add user to leaderboard.
             var username = ctx.User.Username;
@@ -56,17 +55,17 @@ namespace MaraBot.Commands
                 Weekly.Leaderboard = new Dictionary<string, TimeSpan>();
 
             if (Weekly.Leaderboard.ContainsKey(username))
-                Weekly.Leaderboard[username] = time;
+                Weekly.Leaderboard[username] = TimeSpan.MaxValue;
             else
-                Weekly.Leaderboard.Add(username, time);
+                Weekly.Leaderboard.Add(username, TimeSpan.MaxValue);
 
             WeeklyIO.StoreWeeklyAsync(Weekly);
 
-            await ctx.RespondAsync($"Adding {ctx.User.Mention} to the leaderboard!");
+            await ctx.RespondAsync($"{ctx.User.Mention} forfeited the weekly!");
 
             // Grant user their new role.
             var newRole = ctx.Guild.Roles
-                .FirstOrDefault(role => Config.WeeklyCompletedRole.Equals(role.Value.Name));
+                .FirstOrDefault(role => Config.WeeklyForfeitedRole.Equals(role.Value.Name));
 
             if (newRole.Value == null)
             {

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -40,7 +40,6 @@ namespace MaraBot.Commands
         [RequireGuild]
         [RequirePermissions(
             Permissions.SendMessages |
-            Permissions.AddReactions |
             Permissions.AccessChannels)]
         public async Task Execute(CommandContext ctx, int weekNumber = -1)
         {

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -62,16 +62,8 @@ namespace MaraBot.Commands
 
             if (weekNumber == currentWeek)
             {
-                var spoilerChannel = ctx.Guild.Channels
-                    .FirstOrDefault(channel => Config.WeeklySpoilerChannel.Equals(channel.Value.Name));
-
-                if (spoilerChannel.Value == null)
-                {
-                    await ctx.RespondAsync(
-                        "No spoiler channel set.\n" +
-                        "This shouldn't happen! Please contact your friendly neighbourhood developers!");
-                }
-                if (!ctx.Channel.Equals(spoilerChannel.Value))
+                var success = await CommandUtils.VerifyChannel(ctx, Config.WeeklySpoilerChannel);
+                if (!success)
                 {
                     await ctx.RespondAsync("This week's leaderboard can only be displayed on the spoiler channel!");
                     await CommandUtils.SendFailReaction(ctx);
@@ -79,7 +71,7 @@ namespace MaraBot.Commands
                 }
             }
 
-            await ctx.RespondAsync(Display.LeaderboardEmbed(ctx, weekly, false));
+            await ctx.RespondAsync(Display.LeaderboardEmbed(weekly, false));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -71,22 +71,16 @@ namespace MaraBot.Commands
                         "No spoiler channel set.\n" +
                         "This shouldn't happen! Please contact your friendly neighbourhood developers!");
                 }
-                else if (ctx.Channel.Equals(spoilerChannel.Value))
-                {
-                    await ctx.RespondAsync(Display.LeaderboardEmbed(ctx, weekly, false));
-                    await CommandUtils.SendSuccessReaction(ctx);
-                }
-                else
+                if (!ctx.Channel.Equals(spoilerChannel.Value))
                 {
                     await ctx.RespondAsync("This week's leaderboard can only be displayed on the spoiler channel!");
                     await CommandUtils.SendFailReaction(ctx);
+                    return;
                 }
             }
-            else
-            {
-                await ctx.RespondAsync(Display.LeaderboardEmbed(ctx, weekly, false));
-                await CommandUtils.SendSuccessReaction(ctx);
-            }
+
+            await ctx.RespondAsync(Display.LeaderboardEmbed(ctx, weekly, false));
+            await CommandUtils.SendSuccessReaction(ctx);
         }
     }
 }

--- a/MaraBot/Commands/PresetCommandModule.cs
+++ b/MaraBot/Commands/PresetCommandModule.cs
@@ -42,7 +42,7 @@ namespace MaraBot.Commands
                 return;
             }
 
-            await ctx.RespondAsync(Display.PresetEmbed(ctx, Presets[presetName]));
+            await ctx.RespondAsync(Display.PresetEmbed(Presets[presetName]));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/PresetCommandModule.cs
+++ b/MaraBot/Commands/PresetCommandModule.cs
@@ -30,9 +30,7 @@ namespace MaraBot.Commands
         [Description("Get the info on a given preset.")]
         [Cooldown(10, 600, CooldownBucketType.User)]
         [RequireGuild]
-        [RequirePermissions(
-            Permissions.SendMessages |
-            Permissions.AddReactions)]
+        [RequirePermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, string presetName)
         {
             if (!Presets.ContainsKey(presetName))

--- a/MaraBot/Commands/PresetCommandModule.cs
+++ b/MaraBot/Commands/PresetCommandModule.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 
@@ -29,6 +30,9 @@ namespace MaraBot.Commands
         [Description("Get the info on a given preset.")]
         [Cooldown(10, 600, CooldownBucketType.User)]
         [RequireGuild]
+        [RequirePermissions(
+            Permissions.SendMessages |
+            Permissions.AddReactions)]
         public async Task Execute(CommandContext ctx, string presetName)
         {
             if (!Presets.ContainsKey(presetName))
@@ -38,7 +42,7 @@ namespace MaraBot.Commands
                 return;
             }
 
-            await Display.PresetAsync(ctx, Presets[presetName]);
+            await ctx.RespondAsync(Display.PresetEmbed(ctx, Presets[presetName]));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/PresetsCommandModule.cs
+++ b/MaraBot/Commands/PresetsCommandModule.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 
@@ -28,9 +29,12 @@ namespace MaraBot.Commands
         [Description("Get the list of presets.")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
+        [RequirePermissions(
+            Permissions.SendMessages |
+            Permissions.AddReactions)]
         public async Task Execute(CommandContext ctx)
         {
-            await Display.PresetsAsync(ctx, Presets);
+            await ctx.RespondAsync(Display.PresetsEmbed(ctx, Presets));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/PresetsCommandModule.cs
+++ b/MaraBot/Commands/PresetsCommandModule.cs
@@ -29,9 +29,7 @@ namespace MaraBot.Commands
         [Description("Get the list of presets.")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
-        [RequirePermissions(
-            Permissions.SendMessages |
-            Permissions.AddReactions)]
+        [RequirePermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx)
         {
             await ctx.RespondAsync(Display.PresetsEmbed(Presets));

--- a/MaraBot/Commands/PresetsCommandModule.cs
+++ b/MaraBot/Commands/PresetsCommandModule.cs
@@ -34,7 +34,7 @@ namespace MaraBot.Commands
             Permissions.AddReactions)]
         public async Task Execute(CommandContext ctx)
         {
-            await ctx.RespondAsync(Display.PresetsEmbed(ctx, Presets));
+            await ctx.RespondAsync(Display.PresetsEmbed(Presets));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/RaceCommandModule.cs
+++ b/MaraBot/Commands/RaceCommandModule.cs
@@ -45,7 +45,7 @@ namespace MaraBot.Commands
             var seed = RandomUtils.GetRandomSeed();
             var preset = Presets[presetName];
 
-            await ctx.RespondAsync(Display.RaceEmbed(ctx, preset, seed));
+            await ctx.RespondAsync(Display.RaceEmbed(preset, seed));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/RaceCommandModule.cs
+++ b/MaraBot/Commands/RaceCommandModule.cs
@@ -30,9 +30,7 @@ namespace MaraBot.Commands
         [Description("Generate a race based on the preset given.")]
         [Cooldown(3, 600, CooldownBucketType.User)]
         [RequireGuild]
-        [RequirePermissions(
-            Permissions.SendMessages |
-            Permissions.AddReactions)]
+        [RequirePermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, string presetName)
         {
             if (!Presets.ContainsKey(presetName))

--- a/MaraBot/Commands/RaceCommandModule.cs
+++ b/MaraBot/Commands/RaceCommandModule.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 
@@ -29,6 +30,9 @@ namespace MaraBot.Commands
         [Description("Generate a race based on the preset given.")]
         [Cooldown(3, 600, CooldownBucketType.User)]
         [RequireGuild]
+        [RequirePermissions(
+            Permissions.SendMessages |
+            Permissions.AddReactions)]
         public async Task Execute(CommandContext ctx, string presetName)
         {
             if (!Presets.ContainsKey(presetName))
@@ -41,7 +45,7 @@ namespace MaraBot.Commands
             var seed = RandomUtils.GetRandomSeed();
             var preset = Presets[presetName];
 
-            await Display.RaceAsync(ctx, preset, seed);
+            await ctx.RespondAsync(Display.RaceEmbed(ctx, preset, seed));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -33,9 +33,7 @@ namespace MaraBot.Commands
         [Description("Get the weekly race.")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
-        [RequirePermissions(
-            Permissions.SendMessages |
-            Permissions.AddReactions)]
+        [RequirePermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx)
         {
             if (!Presets.ContainsKey(Weekly.PresetName) || Weekly.WeekNumber < 0)

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -43,12 +43,12 @@ namespace MaraBot.Commands
                 await ctx.RespondAsync(
                     $"Weekly preset '{Weekly.PresetName}' is not a a valid preset\n" +
                     "This shouldn't happen! Please contact your friendly neighbourhood developers!");
-                await CommandUtils.SendFailReaction(ctx, false);
+                await CommandUtils.SendFailReaction(ctx);
                 return;
             }
 
             var preset = Presets[Weekly.PresetName];
-            await ctx.RespondAsync(Display.RaceEmbed(ctx, preset, Weekly.Seed, Weekly.Timestamp));
+            await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.Timestamp));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 
@@ -32,6 +33,9 @@ namespace MaraBot.Commands
         [Description("Get the weekly race.")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
+        [RequirePermissions(
+            Permissions.SendMessages |
+            Permissions.AddReactions)]
         public async Task Execute(CommandContext ctx)
         {
             if (!Presets.ContainsKey(Weekly.PresetName) || Weekly.WeekNumber < 0)
@@ -44,7 +48,7 @@ namespace MaraBot.Commands
             }
 
             var preset = Presets[Weekly.PresetName];
-            await Display.RaceAsync(ctx, preset, Weekly.Seed, Weekly.Timestamp);
+            await ctx.RespondAsync(Display.RaceEmbed(ctx, preset, Weekly.Seed, Weekly.Timestamp));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -98,11 +98,13 @@ namespace MaraBot.Core
 
             if (newRole.Value == null)
             {
+                var errorMessage = $"Role {newRole} has not been found in guild {ctx.Guild.Name}.";
+
                 await ctx.RespondAsync(
-                    "No role set for access to spoiler channel.\n" +
+                    errorMessage + "\n" +
                     "This shouldn't happen! Please contact your friendly neighbourhood developers!");
 
-                throw new InvalidOperationException($"role {newRole} has not been found in guild {ctx.Guild.Name}.");
+                throw new InvalidOperationException($"Role {newRole} has not been found in guild {ctx.Guild.Name}.");
             }
 
             await ctx.Member.GrantRoleAsync(newRole.Value);
@@ -121,7 +123,7 @@ namespace MaraBot.Core
                 var errorMessage = $"Channel {channelName} has not been found in guild {ctx.Guild.Name}.";
 
                 await ctx.RespondAsync(
-                    errorMessage +
+                    errorMessage + "\n" +
                     "This shouldn't happen! Please contact your friendly neighbourhood developers!");
 
                 throw new InvalidOperationException(errorMessage);
@@ -143,7 +145,7 @@ namespace MaraBot.Core
                 var errorMessage = $"Channel {channelName} has not been found in guild {ctx.Guild.Name}.";
 
                 await ctx.RespondAsync(
-                    errorMessage +
+                    errorMessage + "\n" +
                     "This shouldn't happen! Please contact your friendly neighbourhood developers!");
 
                 throw new InvalidOperationException(errorMessage);

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -104,7 +104,7 @@ namespace MaraBot.Core
                     errorMessage + "\n" +
                     "This shouldn't happen! Please contact your friendly neighbourhood developers!");
 
-                throw new InvalidOperationException($"Role {newRole} has not been found in guild {ctx.Guild.Name}.");
+                throw new InvalidOperationException(errorMessage);
             }
 
             await ctx.Member.GrantRoleAsync(newRole.Value);

--- a/MaraBot/Core/Config.cs
+++ b/MaraBot/Core/Config.cs
@@ -20,6 +20,18 @@ namespace MaraBot.Core
         /// Roles with race organization privileges.
         /// </summary>
         public IReadOnlyCollection<string> OrganizerRoles { get; }
+        /// <summary>
+        /// Role to give a user whenever they completed a weekly.
+        /// </summary>
+        public string WeeklyCompletedRole { get; }
+        /// <summary>
+        /// Role to give a user whenever they forfeited a weekly.
+        /// </summary>
+        public string WeeklyForfeitedRole { get; }
+        /// <summary>
+        /// Channel with weekly spoilers.
+        /// </summary>
+        public string WeeklySpoilerChannel { get; }
     }
 
     /// <summary>
@@ -33,6 +45,12 @@ namespace MaraBot.Core
         public string Token;
         /// <inheritdoc cref="IConfig.OrganizerRoles"/>
         public string[] OrganizerRoles;
+        /// <inheritdoc cref="IConfig.WeeklyCompletedRole"/>
+        public string WeeklyCompletedRole;
+        /// <inheritdoc cref="IConfig.WeeklyForfeitedRole"/>
+        public string WeeklyForfeitedRole;
+        /// <inheritdoc cref="IConfig.WeeklySpoilerChannel"/>
+        public string WeeklySpoilerChannel;
 
         /// <inheritdoc cref="IConfig.Prefix"/>
         string IConfig.Prefix => Prefix;
@@ -40,5 +58,11 @@ namespace MaraBot.Core
         string IConfig.Token => Token;
         /// <inheritdoc cref="IConfig.OrganizerRoles"/>
         IReadOnlyCollection<string> IConfig.OrganizerRoles => OrganizerRoles;
+        /// <inheritdoc cref="IConfig.WeeklyCompletedRole"/>
+        string IConfig.WeeklyCompletedRole => WeeklyCompletedRole;
+        /// <inheritdoc cref="IConfig.WeeklyForfeitedRole"/>
+        string IConfig.WeeklyForfeitedRole => WeeklyForfeitedRole;
+        /// <inheritdoc cref="IConfig.WeeklySpoilerChannel"/>
+        string IConfig.WeeklySpoilerChannel => WeeklySpoilerChannel;
     }
 }

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -20,6 +20,17 @@ namespace MaraBot.Core
         /// <summary>Timestamp at which weekly seed has been created.</summary>
         public DateTime Timestamp;
 
+        public void AddToLeaderboard(string username, TimeSpan time)
+        {
+            if (Leaderboard == null)
+                Leaderboard = new Dictionary<string, TimeSpan>();
+
+            if (Leaderboard.ContainsKey(username))
+                Leaderboard[username] = time;
+            else
+                Leaderboard.Add(username, time);
+        }
+
         /// <summary>
         /// Retrieves invalid weekly settings.
         /// </summary>

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -31,24 +31,22 @@ namespace MaraBot.Messages
         /// <summary>
         /// Displays race settings.
         /// </summary>
-        /// <param name="ctx">Command Context.</param>
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder RaceEmbed(CommandContext ctx, Preset preset, string seed)
+        public static DiscordEmbedBuilder RaceEmbed(Preset preset, string seed)
         {
-            return RaceEmbed(ctx, preset, seed, DateTime.Now);
+            return RaceEmbed(preset, seed, DateTime.Now);
         }
 
         /// <summary>
         /// Displays race settings.
         /// </summary>
-        /// <param name="ctx">Command Context.</param>
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
         /// <param name="timestamp">Timestamp at which race was generated.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder RaceEmbed(CommandContext ctx, Preset preset, string seed, DateTime timestamp)
+        public static DiscordEmbedBuilder RaceEmbed(Preset preset, string seed, DateTime timestamp)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -77,10 +75,9 @@ namespace MaraBot.Messages
         /// <summary>
         /// Displays available presets.
         /// </summary>
-        /// <param name="ctx">Command Context.</param>
         /// <param name="presets">List of available presets.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder PresetsEmbed(CommandContext ctx, IReadOnlyDictionary<string, Preset> presets)
+        public static DiscordEmbedBuilder PresetsEmbed(IReadOnlyDictionary<string, Preset> presets)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -110,10 +107,9 @@ namespace MaraBot.Messages
         /// <summary>
         /// Displays a preset information.
         /// </summary>
-        /// <param name="ctx">Command Context.</param>
         /// <param name="preset">Preset to display.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder PresetEmbed(CommandContext ctx, Preset preset)
+        public static DiscordEmbedBuilder PresetEmbed(Preset preset)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -178,11 +174,10 @@ namespace MaraBot.Messages
         /// <summary>
         /// Displays the leaderboard for specified weekly.
         /// </summary>
-        /// <param name="ctx">Command Context.</param>
         /// <param name="weekly">Weekly settings.</param>
         /// <param name="preventSpoilers">Hide potential spoilers.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder LeaderboardEmbed(CommandContext ctx, Weekly weekly, bool preventSpoilers)
+        public static DiscordEmbedBuilder LeaderboardEmbed(Weekly weekly, bool preventSpoilers)
         {
             var embed = new DiscordEmbedBuilder
             {

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -34,10 +34,10 @@ namespace MaraBot.Messages
         /// <param name="ctx">Command Context.</param>
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
-        /// <returns>Returns an asynchronous task.</returns>
-        public static Task RaceAsync(CommandContext ctx, Preset preset, string seed)
+        /// <returns>Returns an embed builder.</returns>
+        public static DiscordEmbedBuilder RaceEmbed(CommandContext ctx, Preset preset, string seed)
         {
-            return RaceAsync(ctx, preset, seed, DateTime.Now);
+            return RaceEmbed(ctx, preset, seed, DateTime.Now);
         }
 
         /// <summary>
@@ -47,8 +47,8 @@ namespace MaraBot.Messages
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
         /// <param name="timestamp">Timestamp at which race was generated.</param>
-        /// <returns>Returns an asynchronous task.</returns>
-        public static Task RaceAsync(CommandContext ctx, Preset preset, string seed, DateTime timestamp)
+        /// <returns>Returns an embed builder.</returns>
+        public static DiscordEmbedBuilder RaceEmbed(CommandContext ctx, Preset preset, string seed, DateTime timestamp)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -71,10 +71,7 @@ namespace MaraBot.Messages
                 .AddField("Seed", Formatter.BlockCode(seed))
                 .AddField("Raw Options", Formatter.BlockCode(rawOptionsString));
 
-            var mainBuilder = new DiscordMessageBuilder()
-               .AddEmbed(embed);
-
-            return ctx.RespondAsync(mainBuilder);
+            return embed;
         }
 
         /// <summary>
@@ -82,8 +79,8 @@ namespace MaraBot.Messages
         /// </summary>
         /// <param name="ctx">Command Context.</param>
         /// <param name="presets">List of available presets.</param>
-        /// <returns>Returns an asynchronous task.</returns>
-        public static Task PresetsAsync(CommandContext ctx, IReadOnlyDictionary<string, Preset> presets)
+        /// <returns>Returns an embed builder.</returns>
+        public static DiscordEmbedBuilder PresetsEmbed(CommandContext ctx, IReadOnlyDictionary<string, Preset> presets)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -107,7 +104,7 @@ namespace MaraBot.Messages
                 .AddField("Name", presetNames, true)
                 .AddField("Description", presetDescriptions, true);
 
-            return ctx.RespondAsync(embed);
+            return embed;
         }
 
         /// <summary>
@@ -115,8 +112,8 @@ namespace MaraBot.Messages
         /// </summary>
         /// <param name="ctx">Command Context.</param>
         /// <param name="preset">Preset to display.</param>
-        /// <returns>Returns an asynchronous task.</returns>
-        public static Task PresetAsync(CommandContext ctx, Preset preset)
+        /// <returns>Returns an embed builder.</returns>
+        public static DiscordEmbedBuilder PresetEmbed(CommandContext ctx, Preset preset)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -131,7 +128,7 @@ namespace MaraBot.Messages
                 .AddField("Author", preset.Author)
                 .AddOptions(preset);
 
-            return ctx.RespondAsync(embed);
+            return embed;
         }
 
         private static DiscordEmbedBuilder AddOptionDictionary(this DiscordEmbedBuilder embed, string title, Dictionary<string, string> options)
@@ -184,8 +181,8 @@ namespace MaraBot.Messages
         /// <param name="ctx">Command Context.</param>
         /// <param name="weekly">Weekly settings.</param>
         /// <param name="preventSpoilers">Hide potential spoilers.</param>
-        /// <returns>Returns an asynchronous task.</returns>
-        public static Task LeaderboardAsync(CommandContext ctx, Weekly weekly, bool preventSpoilers)
+        /// <returns>Returns an embed builder.</returns>
+        public static DiscordEmbedBuilder LeaderboardEmbed(CommandContext ctx, Weekly weekly, bool preventSpoilers)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -214,7 +211,7 @@ namespace MaraBot.Messages
             foreach (var entry in leaderboard)
             {
                 userStrings += $"{entry.Key}\n";
-                timeStrings += $"{entry.Value}\n";
+                timeStrings += entry.Value.Equals(TimeSpan.MaxValue) ? "DNF" : $"{entry.Value}\n";
             }
 
             if (preventSpoilers)
@@ -228,7 +225,7 @@ namespace MaraBot.Messages
             embed.AddField("User", userStrings, true);
             embed.AddField("Time", timeStrings, true);
 
-            return ctx.RespondAsync(embed);
+            return embed;
         }
     }
 }

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -73,6 +73,7 @@ namespace MaraBot
             commands.RegisterCommands<Commands.CreatePresetCommandModule>();
             commands.RegisterCommands<Commands.WeeklyCommandModule>();
             commands.RegisterCommands<Commands.CompletedCommandModule>();
+            commands.RegisterCommands<Commands.ForfeitCommandModule>();
             commands.RegisterCommands<Commands.LeaderboardCommandModule>();
 
             foreach(var c in commands) {

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A Secret of Mana Randomizer bot for Discord.
 - `!custom`: Generate a custom race using the .json preset file attached to this message (only available to people with a race organizer role for security reasons).
 - `!preset <presetName>`: Display information for the specified preset.
 - `!presets`: Display all available presets. All presets are in the `presets/` folder.
-- `!newpreset rawOptions`: Generate a JSON preset (with options filled in, if given). Only available in DMs to reduce spam.
+- `!newpreset [rawOptions]`: Generate a JSON preset (with options filled in, if given). Only available in DMs to reduce spam.
 - `!weekly`: Display the current weekly race settings. 
-- `!completed HH:MM:SS`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one. Also gain access to the spoiler channel.
-- `!forfeit`: Forfeit the weekly, but gain access to the spoiler channel.
-- `!leaderboard [weekNumber]`: Display specified week's leaderboard. Without parameters, display this week's leaderboard if in spoiler channel.
+- `!completed <HH:MM:SS>`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one. Also gain access to the spoiler channel.
+- `!forfeit`: Forfeit the weekly, but gain access to the spoiler channel. WIll add you to the leaderboard as DNF.
+- `!leaderboard [weekNumber]`: Display specified week's leaderboard. Without parameters, display this week's leaderboard (only if in spoiler channel).
 
 ## Running a bot instance
 ### Requirements
@@ -28,7 +28,7 @@ For all commands to work, the following permissions must be given to the bot on 
 - Manage Messages
 - Manage Roles (only required for roles defined in `config.json`)
 - Access Channels
-- Add Reactions
+- Add Reactions (optional, used to confirm execution of a command)
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ A Secret of Mana Randomizer bot for Discord.
 - .Net Core: https://dotnet.microsoft.com/download
 - DSharpPlus: https://github.com/DSharpPlus/DSharpPlus
 
+### Permissions
+
+For all commands to work, the following permissions must be given to the bot on discord
+
+- Send Messages
+- Manage Messages
+- Manage Roles
+- Access Channels
+- Add Reactions
+
 ### Configuration
 
 First, follow these guidelines to set up a discord bot account:
@@ -28,9 +38,14 @@ required for the bot to authenticate itself with Discord. Look for
 `config/config_template.json` in the repository for an example, or see below:
 
 ```
-{
   "prefix": "!",
-  "token": "my-token-goes-here"
+  "token": "my-token-goes-here",
+  "organizerRoles": [
+    "organizes races"
+  ],
+  "weeklyCompletedRole": "did the weekly",
+  "weeklyForfeitedRole": "forfeited the weekly",
+  "weeklySpoilerChannel": "spoilers"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ A Secret of Mana Randomizer bot for Discord.
 ## Available commands
 
 - `!race presetName`: Generate a race using the specified preset.
+- `!custom`: Generate a custom race from an imported .json file (Requires file to be uploaded to Discord).
 - `!preset presetName`: Display information for the specified preset.
 - `!presets`: Display all available presets. All presets are in the `presets/` folder.
-- `!newpreset [rawOptions]`: Generate a JSON preset (with options filled in, if given). Only available in DMs to reduce spam.
-- `!weekly`: Generate or return the current weekly race. 
-- `!completed HH:MM:SS`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one.
-- `!leaderboard`: Display the weekly leaderboard.
+- `!newpreset rawOptions`: Generate a JSON preset (with options filled in, if given). Only available in DMs to reduce spam.
+- `!weekly`: Display the current weekly race settings. 
+- `!completed HH:MM:SS`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one. Also gain access to the spoiler channel.
+- `!forfeit`: Forfeit the weekly, but gain access to the spoiler channel.
+- `!leaderboard [weekNumber]`: Display specified week's leaderboard. Without parameters, display this week's leaderboard if in spoiler channel.
 
 ## Running a bot instance
 ### Requirements
@@ -24,7 +26,7 @@ For all commands to work, the following permissions must be given to the bot on 
 
 - Send Messages
 - Manage Messages
-- Manage Roles
+- Manage Roles (only required for roles defined in `config.json`)
 - Access Channels
 - Add Reactions
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A Secret of Mana Randomizer bot for Discord.
 
 ## Available commands
 
-- `!race presetName`: Generate a race using the specified preset.
-- `!custom`: Generate a custom race from an imported .json file (Requires file to be uploaded to Discord).
-- `!preset presetName`: Display information for the specified preset.
+- `!race <presetName>`: Generate a race using the specified preset.
+- `!custom`: Generate a custom race using the .json preset file attached to this message (only available to people with a race organizer role for security reasons).
+- `!preset <presetName>`: Display information for the specified preset.
 - `!presets`: Display all available presets. All presets are in the `presets/` folder.
 - `!newpreset rawOptions`: Generate a JSON preset (with options filled in, if given). Only available in DMs to reduce spam.
 - `!weekly`: Display the current weekly race settings. 

--- a/config/config_template.json
+++ b/config/config_template.json
@@ -3,5 +3,8 @@
   "token": "my-token-goes-here",
   "organizerRoles": [
     "organizes races"
-  ]
+  ],
+  "weeklyCompletedRole": "did the weekly",
+  "weeklyForfeitedRole": "forfeited the weekly",
+  "weeklySpoilerChannel": "spoilers"
 }


### PR DESCRIPTION
Changes to the following commands:
- `!completed` now gives the user the `weeklyCompletedRole` role and posts the leaderboard in the `weeklySpoilerChannel`.
- `!leaderboard` now only display the leaderboard in the spoiler channel for this week's weekly. It does so without spoilers. Previous weeks' leaderboards can still be displayed anywhere.
- new `!forfeit` commands now gives the user the `weeklyForfeitedRole` role and adds them to the leaderboard with a DNF mention. This gives users that want to discuss the weekly but don't want to race access to spoilers.

To allow messages to be sent to other channels, I changed how display commands operate (e.g. `LeaderboardAsync` is now `LeaderboardEmbed`). The commands now create `DiscordEmbedBuilder` that can be displayed anywhere.

Also, to streamline command implementation. I've added `[RequirePermissions()]` attributes to all commands. This allows to
- Remove checks for permissions whenever we call a discord function.
- Give a more generalized view on permissions required to make a command operate successfully.

I added the complete list of permissions required in the README.md.