### PR TITLE
Fixed wrong attribute used to verify bot permissions.

### DIFF
--- a/MaraBot/Commands/CompletedCommandModule.cs
+++ b/MaraBot/Commands/CompletedCommandModule.cs
@@ -38,7 +38,7 @@ namespace MaraBot.Commands
         [Description("Add your time to the leaderboard.")]
         [Cooldown(2, 900, CooldownBucketType.User)]
         [RequireGuild]
-        [RequirePermissions(
+        [RequireBotPermissions(
             Permissions.SendMessages |
             Permissions.ManageMessages |
             Permissions.ManageRoles |

--- a/MaraBot/Commands/CreatePresetCommandModule.cs
+++ b/MaraBot/Commands/CreatePresetCommandModule.cs
@@ -25,7 +25,7 @@ namespace MaraBot.Commands
         [Description("Create a dummy preset file, with options if given.")]
         [Cooldown(5, 600, CooldownBucketType.User)]
         [RequireDirectMessage]
-        [RequirePermissions(Permissions.SendMessages)]
+        [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, [RemainingText] string optionString)
         {
             string[] optionValues = optionString == null ? new string[] { "key=value" } : optionString.Split(' ');

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using MaraBot.Core;
@@ -37,6 +38,7 @@ namespace MaraBot.Commands
         [Description("Start a custom race based on a .json file")]
         [Cooldown(3, 600, CooldownBucketType.User)]
         [RequireGuild]
+        [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx)
         {
             // Safety measure to avoid potential misuses of this command. May be revisited in the future.

--- a/MaraBot/Commands/ForfeitCommandModule.cs
+++ b/MaraBot/Commands/ForfeitCommandModule.cs
@@ -37,7 +37,7 @@ namespace MaraBot.Commands
         [Description("Forfeit the weekly.")]
         [Cooldown(2, 900, CooldownBucketType.User)]
         [RequireGuild]
-        [RequirePermissions(
+        [RequireBotPermissions(
             Permissions.SendMessages |
             Permissions.ManageMessages |
             Permissions.ManageRoles |

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -38,7 +38,7 @@ namespace MaraBot.Commands
         [Aliases("lb")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
-        [RequirePermissions(
+        [RequireBotPermissions(
             Permissions.SendMessages |
             Permissions.AccessChannels)]
         public async Task Execute(CommandContext ctx, int weekNumber = -1)

--- a/MaraBot/Commands/PresetCommandModule.cs
+++ b/MaraBot/Commands/PresetCommandModule.cs
@@ -30,7 +30,7 @@ namespace MaraBot.Commands
         [Description("Get the info on a given preset.")]
         [Cooldown(10, 600, CooldownBucketType.User)]
         [RequireGuild]
-        [RequirePermissions(Permissions.SendMessages)]
+        [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, string presetName)
         {
             if (!Presets.ContainsKey(presetName))

--- a/MaraBot/Commands/PresetsCommandModule.cs
+++ b/MaraBot/Commands/PresetsCommandModule.cs
@@ -29,7 +29,7 @@ namespace MaraBot.Commands
         [Description("Get the list of presets.")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
-        [RequirePermissions(Permissions.SendMessages)]
+        [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx)
         {
             await ctx.RespondAsync(Display.PresetsEmbed(Presets));

--- a/MaraBot/Commands/RaceCommandModule.cs
+++ b/MaraBot/Commands/RaceCommandModule.cs
@@ -30,7 +30,7 @@ namespace MaraBot.Commands
         [Description("Generate a race based on the preset given.")]
         [Cooldown(3, 600, CooldownBucketType.User)]
         [RequireGuild]
-        [RequirePermissions(Permissions.SendMessages)]
+        [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, string presetName)
         {
             if (!Presets.ContainsKey(presetName))

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -33,7 +33,7 @@ namespace MaraBot.Commands
         [Description("Get the weekly race.")]
         [Cooldown(2, 900, CooldownBucketType.Channel)]
         [RequireGuild]
-        [RequirePermissions(Permissions.SendMessages)]
+        [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx)
         {
             if (!Presets.ContainsKey(Weekly.PresetName) || Weekly.WeekNumber < 0)


### PR DESCRIPTION
Seems like we were using the wrong permissions attribute to verify the bot permissions.
It was not an issue in the development discord because we're administrators and have all privileges.

🤦 