### PR TITLE
Reset command for weeklies.

### DIFF
--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -40,19 +40,8 @@ namespace MaraBot.Commands
         public async Task Execute(CommandContext ctx)
         {
             // Safety measure to avoid potential misuses of this command. May be revisited in the future.
-            if (!ctx.Member.Roles.Any(role => (Config.OrganizerRoles?.Contains(role.Name)).GetValueOrDefault()))
+            if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles.ToArray()))
             {
-                var guildRoles = ctx.Guild.Roles
-                    .Where(role => (Config.OrganizerRoles?.Contains(role.Value.Name)).GetValueOrDefault());
-
-                await ctx.RespondAsync(
-                    "Insufficient privileges to create a custom race.\n" +
-                    "This command is only available to the following roles:\n" +
-                    String.Join(
-                        ", ",
-                        await CommandUtils.MentionRoleWithoutPing(ctx, guildRoles.Select(r => r.Value).ToArray())
-                    )
-                );
                 await CommandUtils.SendFailReaction(ctx);
                 return;
             }

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -40,7 +40,7 @@ namespace MaraBot.Commands
         public async Task Execute(CommandContext ctx)
         {
             // Safety measure to avoid potential misuses of this command. May be revisited in the future.
-            if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles.ToArray()))
+            if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles))
             {
                 await CommandUtils.SendFailReaction(ctx);
                 return;

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -61,7 +61,7 @@ namespace MaraBot.Commands
 
             if (weekNumber == currentWeek)
             {
-                var success = await CommandUtils.VerifyChannel(ctx, Config.WeeklySpoilerChannel);
+                var success = await CommandUtils.ChannelExistsInGuild(ctx, Config.WeeklySpoilerChannel);
                 if (!success)
                 {
                     await ctx.RespondAsync("This week's leaderboard can only be displayed on the spoiler channel!");

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -42,7 +42,7 @@ namespace MaraBot.Commands
         public async Task Execute(CommandContext ctx)
         {
             // Safety measure to avoid potential misuses of this command.
-            if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles.ToArray()))
+            if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles))
             {
                 await CommandUtils.SendFailReaction(ctx);
                 return;

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -37,7 +37,6 @@ namespace MaraBot.Commands
         [RequireGuild]
         [RequireBotPermissions(
             Permissions.SendMessages |
-            Permissions.AddReactions |
             Permissions.ManageRoles)]
         public async Task Execute(CommandContext ctx)
         {

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -64,7 +64,7 @@ namespace MaraBot.Commands
             if (Weekly.WeekNumber == currentWeek)
             {
                 await ctx.RespondAsync($"Weekly for week {currentWeek} already exists.");
-                await CommandUtils.SendFailReaction(ctx, false);
+                await CommandUtils.SendFailReaction(ctx);
                 return;
             }
 

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using MaraBot.IO;
+
+namespace MaraBot.Commands
+{
+    using Core;
+    using Messages;
+
+    /// <summary>
+    /// Implements the reset command.
+    /// This command is used to reset the current weekly race.
+    /// </summary>
+    public class ResetWeeklyCommandModule : BaseCommandModule
+    {
+        /// <summary>
+        /// Weekly settings.
+        /// </summary>
+        public Weekly Weekly { private get; set; }
+        /// <summary>
+        /// Bot configuration.
+        /// </summary>
+        public IConfig Config { private get; set; }
+
+        /// <summary>
+        /// Executes the weekly command.
+        /// </summary>
+        /// <param name="ctx">Command Context.</param>
+        /// <returns>Returns an asynchronous task.</returns>
+        [Command("reset")]
+        [Description("Resets the weekly race.")]
+        [Cooldown(2, 900, CooldownBucketType.Channel)]
+        [RequireGuild]
+        [RequirePermissions(
+            Permissions.SendMessages |
+            Permissions.AddReactions |
+            Permissions.ManageRoles)]
+        public async Task Execute(CommandContext ctx)
+        {
+            // Safety measure to avoid potential misuses of this command.
+            if (!ctx.Member.Roles.Any(role => (Config.OrganizerRoles?.Contains(role.Name)).GetValueOrDefault()))
+            {
+                var guildRoles = ctx.Guild.Roles
+                    .Where(role => (Config.OrganizerRoles?.Contains(role.Value.Name)).GetValueOrDefault());
+
+                await ctx.RespondAsync(
+                    "Insufficient privileges to reset the weekly.\n" +
+                    "This command is only available to the following roles:\n" +
+                    String.Join(
+                        ", ",
+                        CommandUtils.MentionRoleWithoutPing(ctx, guildRoles.Select(r => r.Value).ToArray())
+                    )
+                );
+                await CommandUtils.SendFailReaction(ctx);
+                return;
+            }
+
+            var currentWeek = RandomUtils.GetWeekNumber();
+
+            if (Weekly.WeekNumber == currentWeek)
+            {
+                await ctx.RespondAsync($"Weekly for week {currentWeek} already exists.");
+                await CommandUtils.SendFailReaction(ctx, false);
+                return;
+            }
+
+            // Backup weekly settings to json before overriding.
+            WeeklyIO.StoreWeeklyAsync(Weekly, $"weekly.{Weekly.WeekNumber}.json");
+
+            // Set weekly to unset settings until it's rolled out.
+            Weekly.Load(Weekly.NotSet);
+            WeeklyIO.StoreWeeklyAsync(Weekly);
+
+            string[] spoilerRolenames =
+            {
+                Config.WeeklyCompletedRole,
+                Config.WeeklyForfeitedRole
+            };
+
+            var spoilerRoles = ctx.Guild.Roles
+                .Where(role => spoilerRolenames.Contains(role.Value.Name))
+                .Select(role => role.Value);
+
+            await CommandUtils.RevokeSpoilerRoles(ctx, spoilerRoles);
+
+            await ctx.RespondAsync("Weekly has been successfully reset!");
+            await CommandUtils.SendSuccessReaction(ctx);
+        }
+    }
+}

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -114,7 +114,7 @@ namespace MaraBot.Core
         /// <summary>
         /// Revoke all spoiler roles.
         /// </summary>
-        public static async Task RevokeSpoilerRoles(CommandContext ctx, string[] roleStrings)
+        public static async Task RevokeSpoilerRoles(CommandContext ctx, IEnumerable<string> roleStrings)
         {
             var roles = ctx.Guild.Roles
                 .Where(role => roleStrings.Contains(role.Value.Name))
@@ -186,7 +186,7 @@ namespace MaraBot.Core
         /// <summary>
         /// Verifies whether member has a role that is among permitted roles for this command.
         /// </summary>
-        public static async Task<bool> MemberHasPermittedRole(CommandContext ctx, string[] permittedRoles)
+        public static async Task<bool> MemberHasPermittedRole(CommandContext ctx, IEnumerable<string> permittedRoles)
         {
             if (permittedRoles == null)
                 return true;

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -87,7 +87,7 @@ namespace MaraBot.Core
                     ));
             }
 
-            Mode mode = Option.OptionValueToMode(Options["mode"]);
+            Mode mode = Options.ContainsKey("mode") ? Option.OptionValueToMode(Options["mode"]) : Mode.Rando;
             GeneralOptions = new Dictionary<string, string>();
             ModeOptions    = new Dictionary<string, string>();
             OtherOptions   = new Dictionary<string, string>();

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -21,6 +21,19 @@ namespace MaraBot.Core
         public DateTime Timestamp;
 
         /// <summary>
+        /// Load new weekly parameters into weely.
+        /// </summary>
+        /// <param name="weekly">Weekly instance.</param>
+        public void Load(Weekly weekly)
+        {
+            WeekNumber = weekly.WeekNumber;
+            PresetName = weekly.PresetName;
+            Seed = weekly.Seed;
+            Leaderboard = weekly.Leaderboard;
+            Timestamp = weekly.Timestamp;
+        }
+
+        /// <summary>
         /// Retrieves invalid weekly settings.
         /// </summary>
         public static Weekly Invalid => new Weekly
@@ -30,6 +43,15 @@ namespace MaraBot.Core
             Seed = String.Empty,
             Leaderboard = null,
             Timestamp = DateTime.MinValue
+        };
+
+        public static Weekly NotSet => new Weekly
+        {
+            WeekNumber = RandomUtils.GetWeekNumber(),
+            PresetName = "not-set",
+            Seed = "0",
+            Leaderboard = null,
+            Timestamp = DateTime.Now
         };
 
         /// <summary>

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -65,6 +65,9 @@ namespace MaraBot.Messages
                 preset.Options.Select(kvp => $"{kvp.Key}={kvp.Value}")
             );
 
+            if (String.IsNullOrEmpty(rawOptionsString))
+                rawOptionsString = "\u200B";
+
             embed
                 .AddField(preset.Name, preset.Description)
                 .AddOptions(preset)
@@ -161,7 +164,7 @@ namespace MaraBot.Messages
 
         private static DiscordEmbedBuilder AddOptions(this DiscordEmbedBuilder embed, Preset preset)
         {
-            Mode mode = Option.OptionValueToMode(preset.Options["mode"]);
+            Mode mode = preset.Options.ContainsKey("mode") ? Option.OptionValueToMode(preset.Options["mode"]) : Mode.Rando;
 
             embed.AddField(Option.ModeToPrettyString(Mode.Mode), Option.ModeToPrettyString(mode));
 

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -75,6 +75,7 @@ namespace MaraBot
             commands.RegisterCommands<Commands.CompletedCommandModule>();
             commands.RegisterCommands<Commands.ForfeitCommandModule>();
             commands.RegisterCommands<Commands.LeaderboardCommandModule>();
+            commands.RegisterCommands<Commands.ResetWeeklyCommandModule>();
 
             foreach(var c in commands) {
                 c.Value.CommandExecuted += CommandEvents.OnCommandExecuted;

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Secret of Mana Randomizer bot for Discord.
 - `!completed <HH:MM:SS>`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one. Also gain access to the spoiler channel.
 - `!forfeit`: Forfeit the weekly, but gain access to the spoiler channel. WIll add you to the leaderboard as DNF.
 - `!leaderboard [weekNumber]`: Display specified week's leaderboard. Without parameters, display this week's leaderboard (only if in spoiler channel).
+- `!reset`: Reset the current weekly when the week is over.
 
 ## Running a bot instance
 ### Requirements

--- a/presets/not-set.json
+++ b/presets/not-set.json
@@ -1,0 +1,7 @@
+{
+  "name": "Not Set",
+  "description": "Waiting for TheCrashTestGenius to roll new preset!",
+  "version": "1.21",
+  "author": "no-one",
+  "options": {}
+}


### PR DESCRIPTION
Added the `!reset` command to reset the weekly seed.
- This is a "race organizer" only command.
- This can only be used once per week when the week number changes (right now set at UTC 00:00:00 on Friday).
- This doesn't create a new race but rather sets both options and seed to empty strings (to be revisited).
- This backups the last week's weekly to "weekly.{weekNumber}.json".
- This write new weekly to "weekly.json".