### PR TITLE
Spoiler command

### DIFF
--- a/MaraBot/Commands/CompletedCommandModule.cs
+++ b/MaraBot/Commands/CompletedCommandModule.cs
@@ -61,7 +61,7 @@ namespace MaraBot.Commands
             await CommandUtils.SendToChannelAsync(ctx, Config.WeeklySpoilerChannel, message);
 
             // Grant user their new role.
-            await CommandUtils.GrantRoleAsync(ctx, Config.WeeklyCompletedRole);
+            await CommandUtils.GrantRolesToSelfAsync(ctx, new [] {Config.WeeklyCompletedRole});
 
             // Display leaderboard in the spoiler channel.
             await CommandUtils.SendToChannelAsync(ctx, Config.WeeklySpoilerChannel, Display.LeaderboardEmbed(Weekly, false));

--- a/MaraBot/Commands/ForfeitCommandModule.cs
+++ b/MaraBot/Commands/ForfeitCommandModule.cs
@@ -54,7 +54,7 @@ namespace MaraBot.Commands
             await CommandUtils.SendToChannelAsync(ctx, Config.WeeklySpoilerChannel, message);
 
             // Grant user their new role.
-            await CommandUtils.GrantRoleAsync(ctx, Config.WeeklyForfeitedRole);
+            await CommandUtils.GrantRolesToSelfAsync(ctx, new [] {Config.WeeklyForfeitedRole});
 
             // Display leaderboard in the spoiler channel.
             await CommandUtils.SendToChannelAsync(ctx, Config.WeeklySpoilerChannel, Display.LeaderboardEmbed(Weekly, false));

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -63,7 +63,7 @@ namespace MaraBot.Commands
             Weekly.Load(Weekly.NotSet);
             WeeklyIO.StoreWeeklyAsync(Weekly);
 
-            await CommandUtils.RevokeSpoilerRoles(ctx, new []
+            await CommandUtils.RevokeRolesAsync(ctx, new []
             {
                 Config.WeeklyCompletedRole,
                 Config.WeeklyForfeitedRole

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -63,7 +63,7 @@ namespace MaraBot.Commands
             Weekly.Load(Weekly.NotSet);
             WeeklyIO.StoreWeeklyAsync(Weekly);
 
-            await CommandUtils.RevokeRolesAsync(ctx, new []
+            await CommandUtils.RevokeAllRolesAsync(ctx, new []
             {
                 Config.WeeklyCompletedRole,
                 Config.WeeklyForfeitedRole

--- a/MaraBot/Commands/SpoilerRoleCommandModule.cs
+++ b/MaraBot/Commands/SpoilerRoleCommandModule.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using MaraBot.IO;
+
+namespace MaraBot.Commands
+{
+    using Core;
+
+    /// <summary>
+    /// Implements the spoiler command.
+    /// This command is used to manually grant/revoke the spoiler role to certain users.
+    /// </summary>
+    public class SpoilerRoleCommandModule : BaseCommandModule
+    {
+        /// <summary>
+        /// Bot configuration.
+        /// </summary>
+        public IConfig Config { private get; set; }
+
+        /// <summary>
+        /// Executes the weekly command.
+        /// </summary>
+        /// <param name="ctx">Command Context.</param>
+        /// <returns>Returns an asynchronous task.</returns>
+        [Command("spoiler")]
+        [Description("Grant or revoke the spoiler roles.")]
+        [Cooldown(30, 900, CooldownBucketType.Channel)]
+        [RequireGuild]
+        [RequireBotPermissions(
+            Permissions.SendMessages |
+            Permissions.ManageRoles)]
+        public async Task Execute(CommandContext ctx, string optionString, string memberString)
+        {
+            // Safety measure to avoid potential misuses of this command.
+            if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles))
+            {
+                await CommandUtils.SendFailReaction(ctx);
+                return;
+            }
+
+            if (optionString == "done")
+            {
+                await CommandUtils.GrantRolesAsync(ctx, new[] {memberString}, new[] {Config.WeeklyCompletedRole});
+            }
+            else if (optionString == "forfeit")
+            {
+                await CommandUtils.GrantRolesAsync(ctx, new[] {memberString}, new[] {Config.WeeklyForfeitedRole});
+            }
+            else if (optionString == "revoke")
+            {
+                await CommandUtils.RevokeRolesAsync(ctx,
+                    new[] {memberString},
+                    new []
+                    {
+                        Config.WeeklyCompletedRole,
+                        Config.WeeklyForfeitedRole
+                    });
+            }
+            else
+            {
+                await ctx.RespondAsync($"Unrecognized option '{optionString}'");
+                await CommandUtils.SendFailReaction(ctx);
+
+                return;
+            }
+
+            await CommandUtils.SendSuccessReaction(ctx);
+        }
+    }
+}

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -31,7 +31,7 @@ namespace MaraBot
             {
                 Token = config.Token,
                 TokenType = TokenType.Bot,
-                Intents = DiscordIntents.AllUnprivileged
+                Intents = DiscordIntents.AllUnprivileged | DiscordIntents.GuildMembers
             });
 
             var presets = await presetsTask;
@@ -76,6 +76,7 @@ namespace MaraBot
             commands.RegisterCommands<Commands.ForfeitCommandModule>();
             commands.RegisterCommands<Commands.LeaderboardCommandModule>();
             commands.RegisterCommands<Commands.ResetWeeklyCommandModule>();
+            commands.RegisterCommands<Commands.SpoilerRoleCommandModule>();
 
             foreach(var c in commands) {
                 c.Value.CommandExecuted += CommandEvents.OnCommandExecuted;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A Secret of Mana Randomizer bot for Discord.
 ## Available commands
 
 - `!race <presetName>`: Generate a race using the specified preset.
-- `!custom`: Generate a custom race using the .json preset file attached to this message (only available to people with a race organizer role for security reasons).
 - `!preset <presetName>`: Display information for the specified preset.
 - `!presets`: Display all available presets. All presets are in the `presets/` folder.
 - `!newpreset [rawOptions]`: Generate a JSON preset (with options filled in, if given). Only available in DMs to reduce spam.
@@ -13,7 +12,9 @@ A Secret of Mana Randomizer bot for Discord.
 - `!completed <HH:MM:SS>`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one. Also gain access to the spoiler channel.
 - `!forfeit`: Forfeit the weekly, but gain access to the spoiler channel. WIll add you to the leaderboard as DNF.
 - `!leaderboard [weekNumber]`: Display specified week's leaderboard. Without parameters, display this week's leaderboard (only if in spoiler channel).
-- `!reset`: Reset the current weekly when the week is over.
+- `!reset`: Reset the current weekly when the week is over (only available to people with a race organizer role for security reasons).
+- `!custom`: Generate a custom race using the .json preset file attached to this message (only available to people with a race organizer role for security reasons).
+- `!spoiler [rawOptions]`: Grant or Revoke spoiler roles manually (only available to people with a race organizer role for security reasons).
 
 ## Running a bot instance
 ### Requirements


### PR DESCRIPTION
Reworked the Grant/Revoke roles functions in `CommandUtils`. The previous implementation did not retrieve the full list of members from a guild, thus revoking the roles of only certain members when `!reset` was called.

Added a `!spoiler` command to manually grant/revoke spoiler roles for race organizers.
We could remove this eventually if we don't need it.