### PR TITLE
Reworked weekly and weekly reset.

### DIFF
--- a/MaraBot/Commands/CompletedCommandModule.cs
+++ b/MaraBot/Commands/CompletedCommandModule.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
@@ -25,7 +23,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IConfig Config { private get; set; }
+        public IReadOnlyConfig Config { private get; set; }
 
         /// <summary>
         /// Executes the completed command.
@@ -53,7 +51,7 @@ namespace MaraBot.Commands
 
             // Add user to leaderboard.
             Weekly.AddToLeaderboard(ctx.User.Username, time);
-            WeeklyIO.StoreWeeklyAsync(Weekly);
+            await WeeklyIO.StoreWeeklyAsync(Weekly);
 
             // Send message in current channel and in spoiler channel.
             var message = $"Adding {ctx.User.Mention} to the leaderboard!";

--- a/MaraBot/Commands/CompletedCommandModule.cs
+++ b/MaraBot/Commands/CompletedCommandModule.cs
@@ -23,7 +23,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IReadOnlyConfig Config { private get; set; }
+        public Config Config { private get; set; }
 
         /// <summary>
         /// Executes the completed command.

--- a/MaraBot/Commands/CreatePresetCommandModule.cs
+++ b/MaraBot/Commands/CreatePresetCommandModule.cs
@@ -49,13 +49,7 @@ namespace MaraBot.Commands
 
             string message = "";
             if (optionString != null)
-            {
-                message += $"**Options have been validated for randomizer version {PresetValidation.kVersion}. Result:**\n";
-
-                List<string> errors = PresetValidation.ValidateOptions(preset.Options, Options);
-                foreach (var e in errors)
-                    message += $"> {e}\n";
-            }
+                message += PresetValidation.GenerateValidationMessage(preset, Options);
 
             string json = PresetIO.StorePreset(preset);
             message += Formatter.BlockCode(json);

--- a/MaraBot/Commands/CreatePresetCommandModule.cs
+++ b/MaraBot/Commands/CreatePresetCommandModule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
@@ -8,6 +9,7 @@ using Newtonsoft.Json;
 namespace MaraBot.Commands
 {
     using Core;
+    using IO;
 
     /// <summary>
     /// Implements the newpreset command.
@@ -33,40 +35,29 @@ namespace MaraBot.Commands
         [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx, [RemainingText] string optionString)
         {
-            string[] optionValues = optionString == null ? new string[] { "key=value" } : optionString.Split(' ');
-
-            var options = new Dictionary<string, string>();
-
-            foreach(string option in optionValues)
+            Preset preset;
+            try
             {
-                if(!option.Contains('='))
-                {
-                    await ctx.RespondAsync($"'{option}' is not formatted correctly. Format must be 'key=value'.");
-                    await CommandUtils.SendFailReaction(ctx);
-                    return;
-                }
-                string[] values = option.Split('=');
-                options.Add(values[0], values[1]);
+                preset = CommandUtils.CreatePresetFromOptionsString( ctx.User.Username, "DummyName", "DummyDescription", PresetValidation.kVersion, optionString);
             }
-
-            Dictionary<string, object> preset = new Dictionary<string, object>();
-            preset.Add("name", "Dummyname");
-            preset.Add("description", "Dummydescription");
-            preset.Add("version",  PresetValidation.kVersion);
-            preset.Add("author", ctx.User.Username);
-            preset.Add("options", options);
+            catch (InvalidOperationException e)
+            {
+                await ctx.RespondAsync(e.Message);
+                await CommandUtils.SendFailReaction(ctx);
+                return;
+            }
 
             string message = "";
             if (optionString != null)
             {
                 message += $"**Options have been validated for randomizer version {PresetValidation.kVersion}. Result:**\n";
 
-                List<string> errors = PresetValidation.ValidateOptions(options, Options);
+                List<string> errors = PresetValidation.ValidateOptions(preset.Options, Options);
                 foreach (var e in errors)
                     message += $"> {e}\n";
             }
 
-            string json = JsonConvert.SerializeObject(preset, Formatting.Indented);
+            string json = PresetIO.StorePreset(preset);
             message += Formatter.BlockCode(json);
 
             await ctx.RespondAsync(message);

--- a/MaraBot/Commands/CreatePresetCommandModule.cs
+++ b/MaraBot/Commands/CreatePresetCommandModule.cs
@@ -38,7 +38,7 @@ namespace MaraBot.Commands
             Preset preset;
             try
             {
-                preset = CommandUtils.CreatePresetFromOptionsString( ctx.User.Username, "DummyName", "DummyDescription", PresetValidation.kVersion, optionString);
+                preset = CommandUtils.CreatePresetFromOptionsString( ctx.User.Username, "DummyName", "DummyDescription", optionString);
             }
             catch (InvalidOperationException e)
             {

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
@@ -12,8 +9,6 @@ using MaraBot.Messages;
 
 namespace MaraBot.Commands
 {
-    using IO;
-
     /// <summary>
     /// Implements the custom command.
     /// This command is used to create a race using a custom .json preset file.
@@ -48,27 +43,27 @@ namespace MaraBot.Commands
                 return;
             }
 
-            Preset preset = default;
+            Preset preset;
+            var seed = string.Empty;
             try
             {
-                preset = await CommandUtils.LoadPresetAttachmentAsync(ctx, Options);
+                (preset, seed) = await CommandUtils.LoadRaceAttachment(ctx, Options);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException e)
             {
+                await ctx.RespondAsync(e.Message);
                 await CommandUtils.SendFailReaction(ctx);
-                throw;
+                return;
             }
 
-            if (!preset.Equals(default))
-            {
-                // Print validation in separate message to make sure
-                // we can pin just the race embed
-                await ctx.RespondAsync(CommandUtils.ValidatePresetOptions(ctx, preset, Options));
+            // Print validation in separate message to make sure
+            // we can pin just the race embed
+            await ctx.RespondAsync(CommandUtils.ValidatePresetOptions(ctx, preset, Options));
 
-                var seed = RandomUtils.GetRandomSeed();
-                await ctx.RespondAsync(Display.RaceEmbed(preset, seed));
-            }
+            if (string.IsNullOrEmpty(seed))
+                seed = RandomUtils.GetRandomSeed();
 
+            await ctx.RespondAsync(Display.RaceEmbed(preset, seed));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -58,7 +58,7 @@ namespace MaraBot.Commands
 
             // Print validation in separate message to make sure
             // we can pin just the race embed
-            await ctx.RespondAsync(CommandUtils.ValidatePresetOptions(ctx, preset, Options));
+            await ctx.RespondAsync(PresetValidation.GenerateValidationMessage(preset, Options));
 
             if (string.IsNullOrEmpty(seed))
                 seed = RandomUtils.GetRandomSeed();

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -22,7 +22,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IReadOnlyConfig Config { private get; set; }
+        public Config Config { private get; set; }
 
         /// <summary>
         /// Executes the custom command.

--- a/MaraBot/Commands/CustomRaceCommandModule.cs
+++ b/MaraBot/Commands/CustomRaceCommandModule.cs
@@ -28,13 +28,14 @@ namespace MaraBot.Commands
         /// Executes the custom command.
         /// </summary>
         /// <param name="ctx">Command Context.</param>
+        /// <param name="rawArgs">Command line arguments.</param>
         /// <returns>Returns an asynchronous task.</returns>
         [Command("custom")]
         [Description("Start a custom race based on a .json file")]
         [Cooldown(3, 600, CooldownBucketType.User)]
         [RequireGuild]
         [RequireBotPermissions(Permissions.SendMessages)]
-        public async Task Execute(CommandContext ctx)
+        public async Task Execute(CommandContext ctx, [RemainingText][Description(CommandUtils.kCustomRaceArgsDescription)] string rawArgs)
         {
             // Safety measure to avoid potential misuses of this command. May be revisited in the future.
             if (!await CommandUtils.MemberHasPermittedRole(ctx, Config.OrganizerRoles))
@@ -44,10 +45,11 @@ namespace MaraBot.Commands
             }
 
             Preset preset;
-            var seed = string.Empty;
+            string seed;
+            string validationHash;
             try
             {
-                (preset, seed) = await CommandUtils.LoadRaceAttachment(ctx, Options);
+                (preset, seed, validationHash) = await CommandUtils.LoadRaceAttachment(ctx, rawArgs, Options);
             }
             catch (InvalidOperationException e)
             {
@@ -63,7 +65,7 @@ namespace MaraBot.Commands
             if (string.IsNullOrEmpty(seed))
                 seed = RandomUtils.GetRandomSeed();
 
-            await ctx.RespondAsync(Display.RaceEmbed(preset, seed));
+            await ctx.RespondAsync(Display.RaceEmbed(preset, seed, validationHash));
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/ForfeitCommandModule.cs
+++ b/MaraBot/Commands/ForfeitCommandModule.cs
@@ -25,7 +25,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IReadOnlyConfig Config { private get; set; }
+        public Config Config { private get; set; }
 
         /// <summary>
         /// Executes the forfeit command.

--- a/MaraBot/Commands/ForfeitCommandModule.cs
+++ b/MaraBot/Commands/ForfeitCommandModule.cs
@@ -25,7 +25,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IConfig Config { private get; set; }
+        public IReadOnlyConfig Config { private get; set; }
 
         /// <summary>
         /// Executes the forfeit command.
@@ -46,7 +46,7 @@ namespace MaraBot.Commands
         {
             // Add user to leaderboard.
             Weekly.AddToLeaderboard(ctx.User.Username, TimeSpan.MaxValue);
-            WeeklyIO.StoreWeeklyAsync(Weekly);
+            await WeeklyIO.StoreWeeklyAsync(Weekly);
 
             // Send message in current channel and in spoiler channel.
             var message = $"{ctx.User.Mention} forfeited the weekly!";

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus;
@@ -21,11 +22,15 @@ namespace MaraBot.Commands
         /// <summary>
         /// Weekly settings.
         /// </summary>
-        public Weekly Weekly { private get; set; }
+        public IReadOnlyWeekly Weekly { private get; set; }
+        /// <summary>
+        /// Presets settings.
+        /// </summary>
+        public IReadOnlyDictionary<string, Preset> Presets { private get; set; }
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IConfig Config { private get; set; }
+        public IReadOnlyConfig Config { private get; set; }
 
         /// <summary>
         /// Executes the leaderboard command.
@@ -49,7 +54,7 @@ namespace MaraBot.Commands
             var weekly = Weekly;
             if (weekNumber != currentWeek)
             {
-                weekly = await WeeklyIO.LoadWeeklyAsync($"weekly.{weekNumber}.json");
+                weekly = await WeeklyIO.LoadWeeklyAsync(Presets, $"weekly.{weekNumber}.json");
             }
 
             if (weekly.Leaderboard == null || weekly.Leaderboard.Count == 0)

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -30,7 +30,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IReadOnlyConfig Config { private get; set; }
+        public Config Config { private get; set; }
 
         /// <summary>
         /// Executes the leaderboard command.

--- a/MaraBot/Commands/LeaderboardCommandModule.cs
+++ b/MaraBot/Commands/LeaderboardCommandModule.cs
@@ -28,6 +28,10 @@ namespace MaraBot.Commands
         /// </summary>
         public IReadOnlyDictionary<string, Preset> Presets { private get; set; }
         /// <summary>
+        /// Randomizer Options.
+        /// </summary>
+        public IReadOnlyDictionary<string, Option> Options { private get; set; }
+        /// <summary>
         /// Bot configuration.
         /// </summary>
         public Config Config { private get; set; }
@@ -54,7 +58,7 @@ namespace MaraBot.Commands
             var weekly = Weekly;
             if (weekNumber != currentWeek)
             {
-                weekly = await WeeklyIO.LoadWeeklyAsync(Presets, $"weekly.{weekNumber}.json");
+                weekly = await WeeklyIO.LoadWeeklyAsync(Presets, Options, $"weekly.{weekNumber}.json");
             }
 
             if (weekly.Leaderboard == null || weekly.Leaderboard.Count == 0)

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -52,11 +52,13 @@ namespace MaraBot.Commands
                 return;
             }
 
+            var previousWeek = Weekly.WeekNumber;
             var currentWeek = RandomUtils.GetWeekNumber();
+            var backupAndResetWeekly = previousWeek != currentWeek;
 
             // Make a backup of the previous week's weekly and create a new
             // weekly for the current week.
-            if (Weekly.WeekNumber != currentWeek)
+            if (backupAndResetWeekly)
             {
                 try
                 {
@@ -73,11 +75,14 @@ namespace MaraBot.Commands
                 }
 
                 // Backup weekly settings to json before overriding.
-                await WeeklyIO.StoreWeeklyAsync(Weekly, $"weekly.{Weekly.WeekNumber}.json");
+                await WeeklyIO.StoreWeeklyAsync(Weekly, $"weekly.{previousWeek}.json");
 
                 // Set weekly to unset settings until it's rolled out.
                 Weekly.Load(Weekly.NotSet);
                 await WeeklyIO.StoreWeeklyAsync(Weekly);
+
+                await ctx.RespondAsync($"Weekly leaderboard has been successfully reset!");
+                await CommandUtils.SendSuccessReaction(ctx);
             }
 
             // Load in the new preset in attachment.
@@ -103,7 +108,7 @@ namespace MaraBot.Commands
 
             await ctx.RespondAsync(PresetValidation.GenerateValidationMessage(preset, Options));
 
-            Weekly.PresetName = "";
+            Weekly.PresetName = String.Empty;
             Weekly.Preset = preset;
             if (string.IsNullOrEmpty(seed))
             {
@@ -119,7 +124,7 @@ namespace MaraBot.Commands
 
             await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.ValidationHash, Weekly.Timestamp));
 
-            await ctx.RespondAsync("Weekly has been successfully reset!");
+            await ctx.RespondAsync("Weekly preset has been successfully reset!");
             await CommandUtils.SendSuccessReaction(ctx);
         }
     }

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -28,7 +28,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IReadOnlyConfig Config { private get; set; }
+        public Config Config { private get; set; }
 
         /// <summary>
         /// Executes the weekly command.

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
@@ -81,15 +80,17 @@ namespace MaraBot.Commands
             }
 
             // Load in the new preset in attachment.
-            Preset preset = default;
+            Preset preset;
+            var seed = string.Empty;
             try
             {
-                preset = await CommandUtils.LoadPresetAttachmentAsync(ctx, Options);
+                (preset, seed) = await CommandUtils.LoadRaceAttachment(ctx, Options);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException e)
             {
+                await ctx.RespondAsync(e.Message);
                 await CommandUtils.SendFailReaction(ctx);
-                throw;
+                return;
             }
 
             if (preset.Equals(default))
@@ -103,7 +104,7 @@ namespace MaraBot.Commands
             // Roll or reroll weekly seed with preset options.
             Weekly.PresetName = "";
             Weekly.Preset = preset;
-            Weekly.Seed = RandomUtils.GetRandomSeed();
+            Weekly.Seed = string.IsNullOrEmpty(seed) ? RandomUtils.GetRandomSeed() : seed;
             await WeeklyIO.StoreWeeklyAsync(Weekly);
 
             await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.Timestamp));

--- a/MaraBot/Commands/ResetWeeklyCommandModule.cs
+++ b/MaraBot/Commands/ResetWeeklyCommandModule.cs
@@ -99,7 +99,7 @@ namespace MaraBot.Commands
                 await CommandUtils.SendFailReaction(ctx);
             }
 
-            await ctx.RespondAsync(CommandUtils.ValidatePresetOptions(ctx, preset, Options));
+            await ctx.RespondAsync(PresetValidation.GenerateValidationMessage(preset, Options));
 
             // Roll or reroll weekly seed with preset options.
             Weekly.PresetName = "";

--- a/MaraBot/Commands/SpoilerRoleCommandModule.cs
+++ b/MaraBot/Commands/SpoilerRoleCommandModule.cs
@@ -24,7 +24,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IConfig Config { private get; set; }
+        public IReadOnlyConfig Config { private get; set; }
 
         /// <summary>
         /// Grant/Revoke spoiler roles manually.

--- a/MaraBot/Commands/SpoilerRoleCommandModule.cs
+++ b/MaraBot/Commands/SpoilerRoleCommandModule.cs
@@ -24,7 +24,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Bot configuration.
         /// </summary>
-        public IReadOnlyConfig Config { private get; set; }
+        public Config Config { private get; set; }
 
         /// <summary>
         /// Grant/Revoke spoiler roles manually.

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -36,18 +36,32 @@ namespace MaraBot.Commands
         [RequireBotPermissions(Permissions.SendMessages)]
         public async Task Execute(CommandContext ctx)
         {
-            if (!Presets.ContainsKey(Weekly.PresetName) || Weekly.WeekNumber < 0)
+            if (Weekly.WeekNumber < 0)
             {
                 await ctx.RespondAsync(
-                    $"Weekly preset '{Weekly.PresetName}' is not a a valid preset\n" +
-                    "This shouldn't happen! Please contact your friendly neighbourhood developers!");
+                    $"Weekly week number '{Weekly.WeekNumber}' is not valid!\n" +
+                    CommandUtils.kFriendlyMessage);
                 await CommandUtils.SendFailReaction(ctx);
                 return;
             }
 
-            var preset = Presets[Weekly.PresetName];
-            await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.Timestamp));
-            await CommandUtils.SendSuccessReaction(ctx);
+            if (!string.IsNullOrEmpty(Weekly.PresetName))
+            {
+                if (Presets.TryGetValue(Weekly.PresetName, out var preset))
+                {
+                    await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.Timestamp));
+                    await CommandUtils.SendSuccessReaction(ctx);
+                    return;
+                }
+
+                await ctx.RespondAsync($"Weekly preset '{Weekly.PresetName}' is not a a valid preset\n");
+                await CommandUtils.SendFailReaction(ctx);
+            }
+            else
+            {
+                await ctx.RespondAsync(Display.RaceEmbed(Weekly.Preset, Weekly.Seed, Weekly.Timestamp));
+                await CommandUtils.SendSuccessReaction(ctx);
+            }
         }
     }
 }

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -49,7 +49,7 @@ namespace MaraBot.Commands
             {
                 if (Presets.TryGetValue(Weekly.PresetName, out var preset))
                 {
-                    await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.Timestamp));
+                    await ctx.RespondAsync(Display.RaceEmbed(preset, Weekly.Seed, Weekly.ValidationHash, Weekly.Timestamp));
                     await CommandUtils.SendSuccessReaction(ctx);
                     return;
                 }
@@ -59,7 +59,7 @@ namespace MaraBot.Commands
             }
             else
             {
-                await ctx.RespondAsync(Display.RaceEmbed(Weekly.Preset, Weekly.Seed, Weekly.Timestamp));
+                await ctx.RespondAsync(Display.RaceEmbed(Weekly.Preset, Weekly.Seed, Weekly.ValidationHash, Weekly.Timestamp));
                 await CommandUtils.SendSuccessReaction(ctx);
             }
         }

--- a/MaraBot/Commands/WeeklyCommandModule.cs
+++ b/MaraBot/Commands/WeeklyCommandModule.cs
@@ -18,7 +18,7 @@ namespace MaraBot.Commands
         /// <summary>
         /// Weekly settings.
         /// </summary>
-        public Weekly Weekly { private get; set; }
+        public IReadOnlyWeekly Weekly { private get; set; }
         /// <summary>
         /// List of presets available.
         /// </summary>

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -16,7 +16,7 @@ namespace MaraBot.Core
 
     public static class CommandUtils
     {
-        const string kFriendlyMessage = "This shouldn't happen! Please contact your friendly neighbourhood developers!";
+        public const string kFriendlyMessage = "This shouldn't happen! Please contact your friendly neighbourhood developers!";
 
         private enum AttachmentFileType
         {

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -19,9 +19,9 @@ namespace MaraBot.Core
         public const string kFriendlyMessage = "This shouldn't happen! Please contact your friendly neighbourhood developers!";
 
         public const string kCustomRaceArgsDescription = "\n```" +
-                                                         "  --author member    Sets the author of the preset.\n" +
-                                                         "  --name name        Sets the name of the preset.\n" +
-                                                         "  --description      Sets the description of the preset.\n" +
+                                                         "  --author <string>      Sets the author of the preset.\n" +
+                                                         "  --name <string>        Sets the name of the preset.\n" +
+                                                         "  --description <string> Sets the description of the preset.\n" +
                                                          "```";
 
         private enum AttachmentFileType
@@ -408,7 +408,7 @@ namespace MaraBot.Core
         {
             if (ctx.Message.Attachments == null || ctx.Message.Attachments.Count != 1)
             {
-                errorMessage = "No attachment provided. You must supply upload a file when using this command.";
+                errorMessage = "No attachment provided. You must supply a file when using this command.";
                 return AttachmentFileType.Invalid;
             }
 

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -477,14 +477,7 @@ namespace MaraBot.Core
                 options.Add(values[0], values[1]);
             }
 
-            return new Preset
-            {
-                Author = author,
-                Name = name,
-                Description = description,
-                Version = version,
-                Options = options
-            };
+            return new Preset(name, description, version, author, options);
         }
 
         /// <summary>

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -481,24 +481,6 @@ namespace MaraBot.Core
         }
 
         /// <summary>
-        /// Validates the preset options.
-        /// </summary>
-        public static string ValidatePresetOptions(CommandContext ctx, in Preset preset, IReadOnlyDictionary<string, Option> options)
-        {
-            var validationMessage = "";
-            if (preset.Version == PresetValidation.kVersion)
-                validationMessage += "**Preset has been validated successfully. Result:**\n";
-            else
-                validationMessage += $"**Preset randomizer version {preset.Version} doesn't match validator randomizer version {PresetValidation.kVersion}. Validation might be wrong in certain places. Validation Result:**\n";
-
-            List<string> errors = PresetValidation.ValidateOptions(preset.Options, options);
-            foreach (var e in errors)
-                validationMessage += $"> {e}\n";
-
-            return validationMessage;
-        }
-
-        /// <summary>
         /// Converts a positive integer to an ordinal number string.
         /// </summary>
         public static string IntegerToOrdinal(int n)

--- a/MaraBot/Core/CommandUtils.cs
+++ b/MaraBot/Core/CommandUtils.cs
@@ -19,9 +19,9 @@ namespace MaraBot.Core
         public const string kFriendlyMessage = "This shouldn't happen! Please contact your friendly neighbourhood developers!";
 
         public const string kCustomRaceArgsDescription = "\n```" +
-                                                         "  --author <string>      Sets the author of the preset.\n" +
-                                                         "  --name <string>        Sets the name of the preset.\n" +
-                                                         "  --description <string> Sets the description of the preset.\n" +
+                                                         "  --author string      Sets the author of the preset.\n" +
+                                                         "  --name string        Sets the name of the preset.\n" +
+                                                         "  --description string Sets the description of the preset.\n" +
                                                          "```";
 
         private enum AttachmentFileType

--- a/MaraBot/Core/Config.cs
+++ b/MaraBot/Core/Config.cs
@@ -6,7 +6,7 @@ namespace MaraBot.Core
     /// <summary>
     /// Interface that provides a read-only view unto the bot configuration.
     /// </summary>
-    public interface IConfig
+    public interface IReadOnlyConfig
     {
         /// <summary>
         /// Prefix used for discord commands.
@@ -37,32 +37,32 @@ namespace MaraBot.Core
     /// <summary>
     /// Configuration of the bot.
     /// </summary>
-    public class Config : IConfig
+    public class Config : IReadOnlyConfig
     {
-        /// <inheritdoc cref="IConfig.Prefix"/>
+        /// <inheritdoc cref="IReadOnlyConfig.Prefix"/>
         public string Prefix;
-        /// <inheritdoc cref="IConfig.Token"/>
+        /// <inheritdoc cref="IReadOnlyConfig.Token"/>
         public string Token;
-        /// <inheritdoc cref="IConfig.OrganizerRoles"/>
+        /// <inheritdoc cref="IReadOnlyConfig.OrganizerRoles"/>
         public string[] OrganizerRoles;
-        /// <inheritdoc cref="IConfig.WeeklyCompletedRole"/>
+        /// <inheritdoc cref="IReadOnlyConfig.WeeklyCompletedRole"/>
         public string WeeklyCompletedRole;
-        /// <inheritdoc cref="IConfig.WeeklyForfeitedRole"/>
+        /// <inheritdoc cref="IReadOnlyConfig.WeeklyForfeitedRole"/>
         public string WeeklyForfeitedRole;
-        /// <inheritdoc cref="IConfig.WeeklySpoilerChannel"/>
+        /// <inheritdoc cref="IReadOnlyConfig.WeeklySpoilerChannel"/>
         public string WeeklySpoilerChannel;
 
-        /// <inheritdoc cref="IConfig.Prefix"/>
-        string IConfig.Prefix => Prefix;
-        /// <inheritdoc cref="IConfig.Token"/>
-        string IConfig.Token => Token;
-        /// <inheritdoc cref="IConfig.OrganizerRoles"/>
-        IReadOnlyCollection<string> IConfig.OrganizerRoles => OrganizerRoles;
-        /// <inheritdoc cref="IConfig.WeeklyCompletedRole"/>
-        string IConfig.WeeklyCompletedRole => WeeklyCompletedRole;
-        /// <inheritdoc cref="IConfig.WeeklyForfeitedRole"/>
-        string IConfig.WeeklyForfeitedRole => WeeklyForfeitedRole;
-        /// <inheritdoc cref="IConfig.WeeklySpoilerChannel"/>
-        string IConfig.WeeklySpoilerChannel => WeeklySpoilerChannel;
+        /// <inheritdoc cref="IReadOnlyConfig.Prefix"/>
+        string IReadOnlyConfig.Prefix => Prefix;
+        /// <inheritdoc cref="IReadOnlyConfig.Token"/>
+        string IReadOnlyConfig.Token => Token;
+        /// <inheritdoc cref="IReadOnlyConfig.OrganizerRoles"/>
+        IReadOnlyCollection<string> IReadOnlyConfig.OrganizerRoles => OrganizerRoles;
+        /// <inheritdoc cref="IReadOnlyConfig.WeeklyCompletedRole"/>
+        string IReadOnlyConfig.WeeklyCompletedRole => WeeklyCompletedRole;
+        /// <inheritdoc cref="IReadOnlyConfig.WeeklyForfeitedRole"/>
+        string IReadOnlyConfig.WeeklyForfeitedRole => WeeklyForfeitedRole;
+        /// <inheritdoc cref="IReadOnlyConfig.WeeklySpoilerChannel"/>
+        string IReadOnlyConfig.WeeklySpoilerChannel => WeeklySpoilerChannel;
     }
 }

--- a/MaraBot/Core/Config.cs
+++ b/MaraBot/Core/Config.cs
@@ -1,68 +1,43 @@
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace MaraBot.Core
 {
     /// <summary>
-    /// Interface that provides a read-only view unto the bot configuration.
+    /// Configuration of the bot.
     /// </summary>
-    public interface IReadOnlyConfig
+    public class Config
     {
         /// <summary>
         /// Prefix used for discord commands.
         /// </summary>
-        public string Prefix { get; }
+        [JsonProperty]
+        public readonly string Prefix;
         /// <summary>
         /// Discord OAuth token.
         /// </summary>
-        public string Token { get; }
+        [JsonProperty]
+        public readonly string Token;
         /// <summary>
         /// Roles with race organization privileges.
         /// </summary>
-        public IReadOnlyCollection<string> OrganizerRoles { get; }
+        [JsonProperty]
+        public readonly string[] OrganizerRoles;
         /// <summary>
         /// Role to give a user whenever they completed a weekly.
         /// </summary>
-        public string WeeklyCompletedRole { get; }
+        [JsonProperty]
+        public readonly string WeeklyCompletedRole;
         /// <summary>
         /// Role to give a user whenever they forfeited a weekly.
         /// </summary>
-        public string WeeklyForfeitedRole { get; }
+        [JsonProperty]
+        public readonly string WeeklyForfeitedRole;
         /// <summary>
         /// Channel with weekly spoilers.
         /// </summary>
-        public string WeeklySpoilerChannel { get; }
-    }
-
-    /// <summary>
-    /// Configuration of the bot.
-    /// </summary>
-    public class Config : IReadOnlyConfig
-    {
-        /// <inheritdoc cref="IReadOnlyConfig.Prefix"/>
-        public string Prefix;
-        /// <inheritdoc cref="IReadOnlyConfig.Token"/>
-        public string Token;
-        /// <inheritdoc cref="IReadOnlyConfig.OrganizerRoles"/>
-        public string[] OrganizerRoles;
-        /// <inheritdoc cref="IReadOnlyConfig.WeeklyCompletedRole"/>
-        public string WeeklyCompletedRole;
-        /// <inheritdoc cref="IReadOnlyConfig.WeeklyForfeitedRole"/>
-        public string WeeklyForfeitedRole;
-        /// <inheritdoc cref="IReadOnlyConfig.WeeklySpoilerChannel"/>
-        public string WeeklySpoilerChannel;
-
-        /// <inheritdoc cref="IReadOnlyConfig.Prefix"/>
-        string IReadOnlyConfig.Prefix => Prefix;
-        /// <inheritdoc cref="IReadOnlyConfig.Token"/>
-        string IReadOnlyConfig.Token => Token;
-        /// <inheritdoc cref="IReadOnlyConfig.OrganizerRoles"/>
-        IReadOnlyCollection<string> IReadOnlyConfig.OrganizerRoles => OrganizerRoles;
-        /// <inheritdoc cref="IReadOnlyConfig.WeeklyCompletedRole"/>
-        string IReadOnlyConfig.WeeklyCompletedRole => WeeklyCompletedRole;
-        /// <inheritdoc cref="IReadOnlyConfig.WeeklyForfeitedRole"/>
-        string IReadOnlyConfig.WeeklyForfeitedRole => WeeklyForfeitedRole;
-        /// <inheritdoc cref="IReadOnlyConfig.WeeklySpoilerChannel"/>
-        string IReadOnlyConfig.WeeklySpoilerChannel => WeeklySpoilerChannel;
+        [JsonProperty]
+        public readonly string WeeklySpoilerChannel;
     }
 }

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -7,7 +7,7 @@ namespace MaraBot.Core
     /// <summary>
     /// Holds information on an option flags preset.
     /// </summary>
-    public class Preset
+    public struct Preset : IEquatable<Preset>
     {
         /// <summary>
         /// Name of the preset.
@@ -37,17 +37,17 @@ namespace MaraBot.Core
         /// <summary>
         /// List of prettified general options contained in Options.
         /// </summary>
-        [JsonIgnoreAttribute] public Dictionary<string, string> GeneralOptions;
+        [JsonIgnore] public Dictionary<string, string> GeneralOptions;
 
         /// <summary>
         /// List of prettified mode-specific options contained in Options.
         /// </summary>
-        [JsonIgnoreAttribute] public Dictionary<string, string> ModeOptions;
+        [JsonIgnore] public Dictionary<string, string> ModeOptions;
 
         /// <summary>
         /// List of prettified other options contained in Options.
         /// </summary>
-        [JsonIgnoreAttribute] public Dictionary<string, string> OtherOptions;
+        [JsonIgnore] public Dictionary<string, string> OtherOptions;
 
         /// <summary>
         /// Priority of the preset in determining the next weekly preset.
@@ -108,6 +108,21 @@ namespace MaraBot.Core
                 else
                     OtherOptions.Add(option.Item2, option.Item3);
             }
+        }
+
+        public bool Equals(Preset other)
+        {
+            return Name == other.Name && Description == other.Description && Version == other.Version && Author == other.Author;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Preset other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, Description, Version, Author);
         }
     }
 }

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -49,14 +49,17 @@ namespace MaraBot.Core
         /// <summary>
         /// List of prettified general options contained in Options.
         /// </summary>
+        [JsonIgnore]
         public IReadOnlyDictionary<string, string> GeneralOptions => m_GeneralOptions;
         /// <summary>
         /// List of prettified mode-specific options contained in Options.
         /// </summary>
+        [JsonIgnore]
         public IReadOnlyDictionary<string, string> ModeOptions => m_ModeOptions;
         /// <summary>
         /// List of prettified other options contained in Options.
         /// </summary>
+        [JsonIgnore]
         public IReadOnlyDictionary<string, string> OtherOptions => m_OtherOptions;
 
         [JsonIgnore] private Dictionary<string, string> m_GeneralOptions;
@@ -77,7 +80,7 @@ namespace MaraBot.Core
             Description = description;
             Version = version;
             Author = author;
-            Options = options.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Options = new Dictionary<string, string>(options);
             Weight = 1;
             m_GeneralOptions = m_ModeOptions = m_OtherOptions = null;
         }
@@ -92,12 +95,12 @@ namespace MaraBot.Core
             Description = preset.Description;
             Version = preset.Version;
             Author = preset.Author;
-            Options = preset.Options.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Options = new Dictionary<string, string>(preset.Options);
             Weight = preset.Weight;
 
-            m_GeneralOptions = preset.GeneralOptions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            m_ModeOptions = preset.ModeOptions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            m_OtherOptions = preset.OtherOptions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            m_GeneralOptions = new Dictionary<string, string>(preset.GeneralOptions);
+            m_ModeOptions = new Dictionary<string, string>(preset.ModeOptions);
+            m_OtherOptions = new Dictionary<string, string>(preset.OtherOptions);
         }
 
         /// <summary>

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -23,12 +23,6 @@ namespace MaraBot.Core
         public readonly string Description;
 
         /// <summary>
-        /// Version of the randomizer the preset is made for.
-        /// </summary>
-        [JsonProperty]
-        public readonly string Version;
-
-        /// <summary>
         /// Author of the preset.
         /// </summary>
         [JsonProperty]
@@ -74,11 +68,10 @@ namespace MaraBot.Core
         /// <param name="version">Randomizer version for preset.</param>
         /// <param name="author">Preset author.</param>
         /// <param name="options">Collection of raw options.</param>
-        public Preset(string name, string description, string version, string author, IReadOnlyDictionary<string, string> options)
+        public Preset(string name, string description, string author, IReadOnlyDictionary<string, string> options)
         {
             Name = name;
             Description = description;
-            Version = version;
             Author = author;
             Options = new Dictionary<string, string>(options);
             Weight = 1;
@@ -93,7 +86,6 @@ namespace MaraBot.Core
         {
             Name = preset.Name;
             Description = preset.Description;
-            Version = preset.Version;
             Author = preset.Author;
             Options = new Dictionary<string, string>(preset.Options);
             Weight = preset.Weight;
@@ -111,7 +103,8 @@ namespace MaraBot.Core
         {
             var list = new List<Tuple<Mode, string, string>>();
 
-            foreach(var pair in Options) {
+            foreach(var pair in Options)
+            {
                 if(options.ContainsKey(pair.Key)) { // Found key
                     var o = options[pair.Key];
                     if(o.Type == OptionType.List) // List type
@@ -134,11 +127,17 @@ namespace MaraBot.Core
                         ));
                 }
                 else // No key found, use raw values
+                {
+                    // Skip version...
+                    if (pair.Key == "version")
+                        continue;
+
                     list.Add(new Tuple<Mode, string, string>(
                         Mode.Other,
                         pair.Key,
                         pair.Value
                     ));
+                }
             }
 
             Mode mode = Options.ContainsKey("mode") ? Option.OptionValueToMode(Options["mode"]) : Mode.Rando;
@@ -161,7 +160,7 @@ namespace MaraBot.Core
 
         public bool Equals(Preset other)
         {
-            return Name == other.Name && Description == other.Description && Version == other.Version && Author == other.Author;
+            return Name == other.Name && Description == other.Description && Author == other.Author;
         }
 
         public override bool Equals(object obj)
@@ -171,7 +170,7 @@ namespace MaraBot.Core
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Name, Description, Version, Author);
+            return HashCode.Combine(Name, Description, Author);
         }
     }
 }

--- a/MaraBot/Core/PresetValidation.cs
+++ b/MaraBot/Core/PresetValidation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace MaraBot.Core
 {
@@ -8,11 +9,6 @@ namespace MaraBot.Core
     /// </summary>
     public static class PresetValidation
     {
-        /// <summary>
-        /// Randomizer version the validation is written for.
-        /// </summary>
-        public const string kVersion = "1.22";
-
         /// <summary>
         /// Prefix for validation error messages.
         /// </summary>
@@ -37,6 +33,27 @@ namespace MaraBot.Core
         {
             Dictionary<string, string> optionsCopy = new Dictionary<string, string>(preset.Options);
             List<string> errors = new List<string>();
+
+            /*
+             * Version
+             */
+
+            // Version key is required
+            if (!optionsCopy.ContainsKey("version"))
+                errors.Add($"{kValidationErrorPrefix} Options must contain the randomizer version used (e.g. 'version=1.23').");
+            else
+            {
+                var versionRegex = new Regex("^[0-9].[0-9][0-9]$");
+                var versionString = optionsCopy["version"];
+
+                if (!versionRegex.IsMatch(versionString))
+                {
+                    errors.Add($"{kValidationErrorPrefix} '{versionString}' is not a recognized version number.");
+                }
+
+                // Remove version key. Not necessary in further validation.
+                optionsCopy.Remove("version");
+            }
 
             /*
              * Mode
@@ -183,10 +200,6 @@ namespace MaraBot.Core
         public static string GenerateValidationMessage(in Preset preset, IReadOnlyDictionary<string, Option> allOptions)
         {
             var validationMessage = "";
-            if (preset.Version == kVersion)
-                validationMessage += "**Preset has been validated successfully. Result:**\n";
-            else
-                validationMessage += $"**Preset randomizer version {preset.Version} doesn't match validator randomizer version {kVersion}. Validation might be wrong in certain places. Validation Result:**\n";
 
             List<string> errors = ValidateOptions(preset, allOptions);
             foreach (var e in errors)

--- a/MaraBot/Core/PresetValidation.cs
+++ b/MaraBot/Core/PresetValidation.cs
@@ -33,9 +33,9 @@ namespace MaraBot.Core
         /// Returns the empty list if no errors are found.
         /// Otherwise, returns a list of strings explaining the errors.
         /// </summary>
-        public static List<string> ValidateOptions(IReadOnlyDictionary<string, string> options, IReadOnlyDictionary<string, Option> allOptions)
+        public static List<string> ValidateOptions(in Preset preset, IReadOnlyDictionary<string, Option> allOptions)
         {
-            Dictionary<string, string> optionsCopy = new Dictionary<string, string>(options);
+            Dictionary<string, string> optionsCopy = new Dictionary<string, string>(preset.Options);
             List<string> errors = new List<string>();
 
             /*
@@ -133,9 +133,9 @@ namespace MaraBot.Core
                 // Note that we check the actual options,
                 // because we need to know when opSpoilerLog
                 // is unparseable.
-                if (options.ContainsKey("opSpoilerLog") && options["opSpoilerLog"] == "no")
+                if (preset.Options.ContainsKey("opSpoilerLog") && preset.Options["opSpoilerLog"] == "no")
                     errors.Add($"{kValidationGoodPrefix} Options are race-safe.");
-                else if (options.ContainsKey("opSpoilerLog"))
+                else if (preset.Options.ContainsKey("opSpoilerLog"))
                     errors.Add($"{kValidationInfoPrefix} Options might not be race-safe, because I don't know if a spoiler log gets generated.");
                 else
                     errors.Add($"{kValidationInfoPrefix} Options are not race-safe, because a spoiler log gets generated.");
@@ -175,6 +175,24 @@ namespace MaraBot.Core
                 errors.Add($"{kValidationGoodPrefix} All good! :slight_smile:");
 
             return errors;
+        }
+
+        /// <summary>
+        /// Generates a validation message from validated preset options.
+        /// </summary>
+        public static string GenerateValidationMessage(in Preset preset, IReadOnlyDictionary<string, Option> allOptions)
+        {
+            var validationMessage = "";
+            if (preset.Version == kVersion)
+                validationMessage += "**Preset has been validated successfully. Result:**\n";
+            else
+                validationMessage += $"**Preset randomizer version {preset.Version} doesn't match validator randomizer version {kVersion}. Validation might be wrong in certain places. Validation Result:**\n";
+
+            List<string> errors = ValidateOptions(preset, allOptions);
+            foreach (var e in errors)
+                validationMessage += $"> {e}\n";
+
+            return validationMessage;
         }
     }
 }

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -63,6 +63,7 @@ namespace MaraBot.Core
         {
             WeekNumber = weekly.WeekNumber;
             PresetName = weekly.PresetName;
+            Preset = weekly.Preset;
             Seed = weekly.Seed;
             Leaderboard = weekly.Leaderboard;
             Timestamp = weekly.Timestamp;

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -1,18 +1,38 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace MaraBot.Core
 {
+    public interface IReadOnlyWeekly
+    {
+        /// <summary>Week number.</summary>
+        public int WeekNumber { get; }
+        /// <summary>Preset name.</summary>
+        public string PresetName { get; }
+        /// <summary>Preset.</summary>
+        public Preset Preset { get; }
+        /// <summary>Seed used in weekly. This is a string of 16 hexadecimal values.</summary>
+        public string Seed { get; }
+        /// <summary>Leaderboard for the weekly race.</summary>
+        public IReadOnlyDictionary<string, TimeSpan> Leaderboard { get; }
+        /// <summary>Timestamp at which weekly seed has been created.</summary>
+        public DateTime Timestamp { get; }
+    }
+
+
     /// <summary>
     /// Holds information on the weekly race settings.
     /// </summary>
-    public class Weekly
+    public class Weekly : IReadOnlyWeekly
     {
         /// <summary>Week number.</summary>
         public int WeekNumber;
         /// <summary>Preset name.</summary>
         public string PresetName;
+        /// <summary>Preset.</summary>
+        public Preset Preset;
         /// <summary>Seed used in weekly. This is a string of 16 hexadecimal values.</summary>
         public string Seed;
         /// <summary>Leaderboard for the weekly race.</summary>
@@ -107,5 +127,12 @@ namespace MaraBot.Core
                 Timestamp = DateTime.Now
             };
         }
+
+        int IReadOnlyWeekly.WeekNumber => WeekNumber;
+        string IReadOnlyWeekly.PresetName => PresetName;
+        Preset IReadOnlyWeekly.Preset => Preset;
+        string IReadOnlyWeekly.Seed => Seed;
+        IReadOnlyDictionary<string, TimeSpan> IReadOnlyWeekly.Leaderboard => Leaderboard;
+        DateTime IReadOnlyWeekly.Timestamp => Timestamp;
     }
 }

--- a/MaraBot/Core/Weekly.cs
+++ b/MaraBot/Core/Weekly.cs
@@ -15,6 +15,8 @@ namespace MaraBot.Core
         public Preset Preset { get; }
         /// <summary>Seed used in weekly. This is a string of 16 hexadecimal values.</summary>
         public string Seed { get; }
+        /// <summary>Validation Hash. This is a string of 8 hexadecimal values (optional).</summary>
+        public string ValidationHash { get; }
         /// <summary>Leaderboard for the weekly race.</summary>
         public IReadOnlyDictionary<string, TimeSpan> Leaderboard { get; }
         /// <summary>Timestamp at which weekly seed has been created.</summary>
@@ -35,6 +37,8 @@ namespace MaraBot.Core
         public Preset Preset;
         /// <summary>Seed used in weekly. This is a string of 16 hexadecimal values.</summary>
         public string Seed;
+        /// <summary>Validation Hash. This is a string of 8 hexadecimal values (optional).</summary>
+        public string ValidationHash;
         /// <summary>Leaderboard for the weekly race.</summary>
         public Dictionary<string, TimeSpan> Leaderboard;
         /// <summary>Timestamp at which weekly seed has been created.</summary>
@@ -72,6 +76,7 @@ namespace MaraBot.Core
             WeekNumber = -1,
             PresetName = String.Empty,
             Seed = String.Empty,
+            ValidationHash = String.Empty,
             Leaderboard = null,
             Timestamp = DateTime.MinValue
         };
@@ -81,6 +86,7 @@ namespace MaraBot.Core
             WeekNumber = RandomUtils.GetWeekNumber(),
             PresetName = "not-set",
             Seed = "0",
+            ValidationHash = String.Empty,
             Leaderboard = null,
             Timestamp = DateTime.Now
         };
@@ -123,6 +129,7 @@ namespace MaraBot.Core
                 WeekNumber = weekNumber,
                 PresetName = presetName,
                 Seed = seed,
+                ValidationHash = String.Empty,
                 Leaderboard = new Dictionary<string, TimeSpan>(),
                 Timestamp = DateTime.Now
             };
@@ -132,6 +139,7 @@ namespace MaraBot.Core
         string IReadOnlyWeekly.PresetName => PresetName;
         Preset IReadOnlyWeekly.Preset => Preset;
         string IReadOnlyWeekly.Seed => Seed;
+        string IReadOnlyWeekly.ValidationHash => ValidationHash;
         IReadOnlyDictionary<string, TimeSpan> IReadOnlyWeekly.Leaderboard => Leaderboard;
         DateTime IReadOnlyWeekly.Timestamp => Timestamp;
     }

--- a/MaraBot/IO/PresetIO.cs
+++ b/MaraBot/IO/PresetIO.cs
@@ -76,7 +76,7 @@ namespace MaraBot.IO
         public static Preset LoadPreset(string jsonContent, IReadOnlyDictionary<string, Option> options)
         {
             var preset = JsonConvert.DeserializeObject<Preset>(jsonContent);
-            preset?.MakeDisplayable(options);
+            preset.MakeDisplayable(options);
 
             return preset;
         }

--- a/MaraBot/IO/PresetIO.cs
+++ b/MaraBot/IO/PresetIO.cs
@@ -80,5 +80,15 @@ namespace MaraBot.IO
 
             return preset;
         }
+
+        /// <summary>
+        /// Stores a single preset to a JSON buffer.
+        /// </summary>
+        /// <param name="preset">Preset</param>
+        /// <returns>JSON buffer.</returns>
+        public static string StorePreset(in Preset preset)
+        {
+            return JsonConvert.SerializeObject(preset, Formatting.Indented);
+        }
     }
 }

--- a/MaraBot/IO/WeeklyIO.cs
+++ b/MaraBot/IO/WeeklyIO.cs
@@ -72,7 +72,7 @@ namespace MaraBot.IO
                 {
                     if (presets.TryGetValue(weekly.PresetName, out var preset))
                     {
-                        weekly.Preset = preset;
+                        weekly.Preset = new Preset(preset);
                     }
                 }
 

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -182,7 +182,7 @@ namespace MaraBot.Messages
         /// <param name="weekly">Weekly settings.</param>
         /// <param name="preventSpoilers">Hide potential spoilers.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder LeaderboardEmbed(Weekly weekly, bool preventSpoilers)
+        public static DiscordEmbedBuilder LeaderboardEmbed(IReadOnlyWeekly weekly, bool preventSpoilers)
         {
             var embed = new DiscordEmbedBuilder
             {

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -31,10 +31,11 @@ namespace MaraBot.Messages
         /// </summary>
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
+        /// <param name="validationHash">Validation hash (optional).</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder RaceEmbed(in Preset preset, string seed)
+        public static DiscordEmbedBuilder RaceEmbed(in Preset preset, string seed, string validationHash = default)
         {
-            return RaceEmbed(preset, seed, DateTime.Now);
+            return RaceEmbed(preset, seed, validationHash, DateTime.Now);
         }
 
         /// <summary>
@@ -42,9 +43,10 @@ namespace MaraBot.Messages
         /// </summary>
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
+        /// <param name="validationHash"></param>
         /// <param name="timestamp">Timestamp at which race was generated.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder RaceEmbed(in Preset preset, string seed, DateTime timestamp)
+        public static DiscordEmbedBuilder RaceEmbed(in Preset preset, string seed, string validationHash, DateTime timestamp)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -64,11 +66,22 @@ namespace MaraBot.Messages
             if (String.IsNullOrEmpty(rawOptionsString))
                 rawOptionsString = "\u200B";
 
+            if (!String.IsNullOrEmpty(preset.Name))
+            {
+                embed.AddField(preset.Name, preset.Description);
+            }
+
             embed
-                .AddField(preset.Name, preset.Description)
+                .AddField("Author", preset.Author)
                 .AddOptions(preset)
-                .AddField("Seed", Formatter.BlockCode(seed))
-                .AddField("Raw Options", Formatter.BlockCode(rawOptionsString));
+                .AddField("Seed", Formatter.BlockCode(seed));
+
+            if (!String.IsNullOrEmpty(validationHash))
+            {
+                embed.AddField("Validation Hash", Formatter.BlockCode(validationHash));
+            }
+
+            embed.AddField("Raw Options", Formatter.BlockCode(rawOptionsString));
 
             return embed;
         }
@@ -121,7 +134,6 @@ namespace MaraBot.Messages
             embed
                 .AddField("Preset", preset.Name)
                 .AddField("Description", preset.Description)
-                .AddField("Version", preset.Version)
                 .AddField("Author", preset.Author)
                 .AddOptions(preset);
 
@@ -163,8 +175,11 @@ namespace MaraBot.Messages
         private static DiscordEmbedBuilder AddOptions(this DiscordEmbedBuilder embed, Preset preset)
         {
             Mode mode = preset.Options.ContainsKey("mode") ? Option.OptionValueToMode(preset.Options["mode"]) : Mode.Rando;
+            string version = preset.Options.ContainsKey("version") ? preset.Options["version"] : "n/a";
 
-            embed.AddField(Option.ModeToPrettyString(Mode.Mode), Option.ModeToPrettyString(mode));
+            embed
+                .AddField(Option.ModeToPrettyString(Mode.Mode), Option.ModeToPrettyString(mode))
+                .AddField("Version", version);
 
             if (preset.GeneralOptions.Count > 0)
                 embed.AddOptionDictionary($"{Option.ModeToPrettyString(Mode.General)} Options", preset.GeneralOptions);

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -32,7 +32,7 @@ namespace MaraBot.Messages
         /// <param name="preset">Preset used in race.</param>
         /// <param name="seed">Generated seed.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder RaceEmbed(Preset preset, string seed)
+        public static DiscordEmbedBuilder RaceEmbed(in Preset preset, string seed)
         {
             return RaceEmbed(preset, seed, DateTime.Now);
         }
@@ -44,7 +44,7 @@ namespace MaraBot.Messages
         /// <param name="seed">Generated seed.</param>
         /// <param name="timestamp">Timestamp at which race was generated.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder RaceEmbed(Preset preset, string seed, DateTime timestamp)
+        public static DiscordEmbedBuilder RaceEmbed(in Preset preset, string seed, DateTime timestamp)
         {
             var embed = new DiscordEmbedBuilder
             {
@@ -110,7 +110,7 @@ namespace MaraBot.Messages
         /// </summary>
         /// <param name="preset">Preset to display.</param>
         /// <returns>Returns an embed builder.</returns>
-        public static DiscordEmbedBuilder PresetEmbed(Preset preset)
+        public static DiscordEmbedBuilder PresetEmbed(in Preset preset)
         {
             var embed = new DiscordEmbedBuilder
             {

--- a/MaraBot/Messages/Display.cs
+++ b/MaraBot/Messages/Display.cs
@@ -128,7 +128,7 @@ namespace MaraBot.Messages
             return embed;
         }
 
-        private static DiscordEmbedBuilder AddOptionDictionary(this DiscordEmbedBuilder embed, string title, Dictionary<string, string> options)
+        private static DiscordEmbedBuilder AddOptionDictionary(this DiscordEmbedBuilder embed, string title, IReadOnlyDictionary<string, string> options)
         {
             int numberOfColumns = Math.Min((int)Math.Ceiling(options.Count / (float) kMinNumberOfElementsPerColumn), kMaxNumberOfColumns);
             int numberOfElementsPerColumn = (int)Math.Ceiling(options.Count / (float) numberOfColumns);

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -23,7 +23,7 @@ namespace MaraBot
             var configTask = ConfigIO.LoadConfigAsync();
             var options = await OptionsIO.LoadOptionsAsync();
             var presets = await PresetIO.LoadPresetsAsync(options);
-            var weeklyTask = WeeklyIO.LoadWeeklyAsync(presets);
+            var weeklyTask = WeeklyIO.LoadWeeklyAsync(presets, options);
             var responsesTask = EightBallIO.LoadResponsesAsync();
 
             var config = await configTask;

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -21,9 +21,9 @@ namespace MaraBot
         static async Task MainAsync()
         {
             var configTask = ConfigIO.LoadConfigAsync();
-            var weeklyTask = WeeklyIO.LoadWeeklyAsync();
             var options = await OptionsIO.LoadOptionsAsync();
-            var presetsTask = PresetIO.LoadPresetsAsync(options);
+            var presets = await PresetIO.LoadPresetsAsync(options);
+            var weeklyTask = WeeklyIO.LoadWeeklyAsync(presets);
             var responsesTask = EightBallIO.LoadResponsesAsync();
 
             var config = await configTask;
@@ -35,16 +35,16 @@ namespace MaraBot
                 Intents = DiscordIntents.AllUnprivileged | DiscordIntents.GuildMembers
             });
 
-            var presets = await presetsTask;
             var weekly = await weeklyTask;
             var responses = await responsesTask;
 
             var services = new ServiceCollection()
                 .AddSingleton<IReadOnlyDictionary<string, Preset>>(_ => presets)
                 .AddSingleton<IReadOnlyDictionary<string, Option>>(_ => options)
-                .AddSingleton<IConfig>(_ => config)
-                .AddSingleton<string[]>(_ => responses)
+                .AddSingleton<IReadOnlyConfig>(_ => config)
+                .AddSingleton(responses)
                 .AddSingleton(weekly)
+                .AddSingleton<IReadOnlyWeekly>(_ => weekly)
                 .BuildServiceProvider();
 
             // Test for network before connecting to discord.

--- a/MaraBot/Program.cs
+++ b/MaraBot/Program.cs
@@ -41,7 +41,7 @@ namespace MaraBot
             var services = new ServiceCollection()
                 .AddSingleton<IReadOnlyDictionary<string, Preset>>(_ => presets)
                 .AddSingleton<IReadOnlyDictionary<string, Option>>(_ => options)
-                .AddSingleton<IReadOnlyConfig>(_ => config)
+                .AddSingleton(config)
                 .AddSingleton(responses)
                 .AddSingleton(weekly)
                 .AddSingleton<IReadOnlyWeekly>(_ => weekly)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ A Secret of Mana Randomizer bot for Discord.
 - `!completed <HH:MM:SS>`: Add your name to the leaderboard for the weekly race or override your time in the leaderboard with a new one. Also gain access to the spoiler channel.
 - `!forfeit`: Forfeit the weekly, but gain access to the spoiler channel. WIll add you to the leaderboard as DNF.
 - `!leaderboard [weekNumber]`: Display specified week's leaderboard. Without parameters, display this week's leaderboard (only if in spoiler channel).
-- `!reset`: Reset the current weekly when the week is over (only available to people with a race organizer role for security reasons).
-- `!custom`: Generate a custom race using the .json preset file attached to this message (only available to people with a race organizer role for security reasons).
-- `!spoiler [rawOptions]`: Grant or Revoke spoiler roles manually (only available to people with a race organizer role for security reasons).
+- `!reset [--author string][--name string][--description string]`: Reset the current weekly when the week is over and create a new race using a .json preset or .txt log file attached to this message. (only available to people with a race organizer role for security reasons).
+- `!custom`: Generate a custom race using the .json preset or .txt log file attached to this message (only available to people with a race organizer role for security reasons).
+- `!spoiler [--done member][--completed member][--forfeit member][--revoke member]`: Grant or Revoke spoiler roles manually (only available to people with a race organizer role for security reasons).
+- `!8ball [rawOptions]`: Ask Mara a question and bask in her wisdom!!! 
 
 ## Running a bot instance
 ### Requirements


### PR DESCRIPTION
This pull-request brings in some new features to weeklies that will allow race organizers to reset the weekly races themselves without having to restart the bot.

- `!reset` command now has to option to load from an attachment file.
- Attachment files can either be `.json` preset files, or `.txt` non-spoiler log files generated by `SoMAncientCave.exe`.

Additionally, I've made some refactoring to the following:

- Isolated attachment loading functions, and raw option parsing in `CommandUtils.cs`.
- Isolated validation message generation in `PresetValidation.cs`.
- Changed `Preset` and `Config` properties to read-only to more safely share them among command implementations.
- Added a `IReadOnlyWeekly` interface to `Weekly` to allow a read-only view on weekly properties for commands that don't require writing access.