### PR TITLE
Reworked option system

### DIFF
--- a/MaraBot/Core/Option.cs
+++ b/MaraBot/Core/Option.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -19,18 +21,9 @@ namespace MaraBot.Core
     }
 
     /// <summary>
-    /// Type of value an Option has.
-    /// </summary>
-    public enum OptionType
-    {
-        Enum, // Select one value from Values
-        List  // Select multiple values from Values, separated by a comma
-    }
-
-    /// <summary>
     /// Information about a randomizer option.
     /// </summary>
-    public struct Option
+    public abstract class Option
     {
         /// <summary>
         /// Name of the options, as seen in the randomizer.
@@ -43,29 +36,26 @@ namespace MaraBot.Core
         public readonly Mode Mode;
 
         /// <summary>
-        /// Type of value it supports.
+        /// Does this option accept a comma separated list of values?
         /// </summary>
-        [DefaultValue(OptionType.Enum)]
-        public readonly OptionType Type;
-
-        /// <summary>
-        /// Possible values the option can have in the options JSON/string,
-        /// together with the display name as seen in the randomizer.
-        /// Default values will not be in this dictionary,
-        /// because those values don't appear in the options string.
-        /// </summary>
-        public readonly IDictionary<string, string> Values;
+        [DefaultValue(false)]
+        public readonly bool List = false;
 
         /// <summary>
         /// Create an Option with specified properties.
         /// </summary>
-        public Option(string name, Mode mode, OptionType type, IDictionary<string, string> values)
+        public Option(string name, Mode mode, bool list = false)
         {
-            Name   = name  ;
-            Mode   = mode  ;
-            Values = values;
-            Type   = type  ;
+            Name = name;
+            Mode = mode;
+            List = list;
         }
+
+        /// <summary>
+        /// Make a human-readable version of the given value.
+        /// When in list mode, this function will be called for every list entry.
+        /// </summary>
+        protected abstract string ParseValueItem(string val);
 
         /// <summary>
         /// Translate a mode to a human-readable string.
@@ -104,10 +94,116 @@ namespace MaraBot.Core
         /// <summary>
         /// Transform a string list of values (OptionType.List) into a List.
         /// </summary>
-        public static List<string> ParseList(string values) {
+        public static List<string> ParseList(string values)
+        {
             var list = new List<string>(values.Split(','));
             list.RemoveAll(s => s == "");
             return list;
+        }
+
+        /// <summary>
+        /// Parse a raw option value of this type into a human-readable value.
+        /// </summary>
+        public string ParseValue(string val)
+        {
+            return String.Join
+            (
+                ", ",
+                (this.List ? Option.ParseList(val) : new List<string> { val }).Select(this.ParseValueItem)
+            );
+        }
+    }
+
+    /// <summary>
+    /// Information about a randomizer enum option.
+    /// </summary>
+    public class EnumOption : Option
+    {
+        /// <summary>
+        /// Possible values the option can have in the options JSON/string,
+        /// together with the display name as seen in the randomizer.
+        /// Default values will not be in this dictionary,
+        /// because those values don't appear in the options string.
+        /// Used when `Type == OptionType.Enum`.
+        /// </summary>
+        public readonly IDictionary<string, string> Values;
+
+        /// <summary>
+        /// Create an EnumOption with specified properties.
+        /// </summary>
+        public EnumOption(string name, Mode mode, IDictionary<string, string> values, bool list = false)
+            : base(name, mode, list)
+        {
+            Values = values;
+        }
+
+        protected override string ParseValueItem(string val)
+        {
+            return Values.ContainsKey(val) ? Values[val] : val;
+        }
+    }
+
+    /// <summary>
+    /// Information about a randomizer numeric option.
+    /// </summary>
+    public class NumericOption : Option
+    {
+        /// <summary>
+        /// Maximum decimal precision allowed.
+        /// * 0 means the number must be an integer.
+        /// * X > 0 means the number can have at most X decimal digits.
+        /// * 0 > X means the number must be an integer with at least X trailing zeroes.
+        /// Used when `Type == OptionType.Numeric`.
+        /// Precision must be between -10 and 10.
+        /// </summary>
+        [DefaultValue(10)]
+        public readonly int Precision;
+
+        /// <summary>
+        /// Minimum value for numeric values.
+        /// Used when `Type == OptionType.Numeric`.
+        /// </summary>
+        [DefaultValue(double.MinValue)]
+        public readonly double Min;
+
+        /// <summary>
+        /// Maximum value for numeric values.
+        /// Used when `Type == OptionType.Numeric`.
+        /// </summary>
+        [DefaultValue(double.MaxValue)]
+        public readonly double Max;
+
+        /// <summary>
+        /// Create a NumericOption with specified properties.
+        /// </summary>
+        public NumericOption(string name, Mode mode, int precision, double min, double max, bool list = false)
+            : base(name, mode, list)
+        {
+            Precision = precision;
+            Min       = min      ;
+            Max       = max      ;
+        }
+
+        protected override string ParseValueItem(string val)
+        {
+            if (Precision > 0)
+            {
+                // double
+                double v;
+                bool success = double.TryParse(val, out v);
+                if (!success)
+                    return val;
+                return v.ToString($"F{Precision.ToString()}");
+            }
+            else
+            {
+                // int
+                int v;
+                bool success = int.TryParse(val, out v);
+                if (!success)
+                    return val;
+                return v.ToString(); // TODO: add rounding for Precision < 0
+            }
         }
     }
 }

--- a/MaraBot/Core/Option.cs
+++ b/MaraBot/Core/Option.cs
@@ -189,8 +189,7 @@ namespace MaraBot.Core
             if (Precision > 0)
             {
                 // double
-                double v;
-                bool success = double.TryParse(val, out v);
+                bool success = double.TryParse(val, out var v);
                 if (!success)
                     return val;
                 return v.ToString($"F{Precision.ToString()}");
@@ -198,8 +197,7 @@ namespace MaraBot.Core
             else
             {
                 // int
-                int v;
-                bool success = int.TryParse(val, out v);
+                bool success = int.TryParse(val, out var v);
                 if (!success)
                     return val;
                 return v.ToString(); // TODO: add rounding for Precision < 0

--- a/MaraBot/Core/Preset.cs
+++ b/MaraBot/Core/Preset.cs
@@ -105,38 +105,17 @@ namespace MaraBot.Core
 
             foreach(var pair in Options)
             {
-                if(options.ContainsKey(pair.Key)) { // Found key
+                if(options.ContainsKey(pair.Key)) // Found key
+                {
                     var o = options[pair.Key];
-                    if(o.Type == OptionType.List) // List type
-                        list.Add(new Tuple<Mode, string, string>(
-                            o.Mode,
-                            o.Name,
-                            String.Join(", ", Option.ParseList(pair.Value).ConvertAll(
-                                v => o.Values.ContainsKey(v)
-                                        ? o.Values[v] // Value found
-                                        : v // No value found, use raw value
-                            ))
-                        ));
-                    else // Enum type
-                        list.Add(new Tuple<Mode, string, string>(
-                            o.Mode,
-                            o.Name,
-                            o.Values.ContainsKey(pair.Value)
-                                    ? o.Values[pair.Value] // Value found
-                                    : pair.Value // No value found, use raw value
-                        ));
+                    list.Add(new Tuple<Mode, string, string>(o.Mode, o.Name, o.ParseValue(pair.Value)));
                 }
                 else // No key found, use raw values
                 {
                     // Skip version...
                     if (pair.Key == "version")
                         continue;
-
-                    list.Add(new Tuple<Mode, string, string>(
-                        Mode.Other,
-                        pair.Key,
-                        pair.Value
-                    ));
+                    list.Add(new Tuple<Mode, string, string>(Mode.Other, pair.Key, pair.Value));
                 }
             }
 

--- a/MaraBot/Core/PresetValidation.cs
+++ b/MaraBot/Core/PresetValidation.cs
@@ -116,8 +116,7 @@ namespace MaraBot.Core
                     // Skip if value is not within bounds
                     foreach (var o in option.List ? Option.ParseList(pair.Value) : new List<string> { pair.Value })
                     {
-                        double v;
-                        bool success = double.TryParse(o, out v);
+                        bool success = double.TryParse(o, out var v);
                         if(!success)
                         {
                             errors.Add($"{kValidationErrorPrefix} '{pair.Key}' has non-numeric value '{o}'");

--- a/MaraBot/Core/PresetValidation.cs
+++ b/MaraBot/Core/PresetValidation.cs
@@ -144,9 +144,13 @@ namespace MaraBot.Core
                 if ((!optionsCopy.ContainsKey("opEnemies") || optionsCopy["opEnemies"] != "oops") && optionsCopy.ContainsKey("oopsAllThis"))
                     errors.Add($"{kValidationInfoPrefix} Selecting a different 'Oops! All owls' enemy is useless if you don't have 'Oops! All owls' enabled.");
 
-                // If 'Enemy stat growth' is set to 'None (vanilla), setting a difficulty doesn't make sense
+                // If 'Enemy stat growth' is set to 'None (vanilla)', setting a difficulty doesn't make sense
                 if (optionsCopy.ContainsKey("opStatGrowth") && optionsCopy["opStatGrowth"] == "vanilla" && optionsCopy.ContainsKey("opDifficulty"))
                     errors.Add($"{kValidationInfoPrefix} Selecting a different difficulty is useless if you have vanilla enemy stat growth enabled.");
+
+                // If 'Enemy stat growth' is not set to 'No Future', setting a "No Future" level doesn't make sense
+                if ((!optionsCopy.ContainsKey("opStatGrowth") || optionsCopy["opStatGrowth"] != "nofuture") && optionsCopy.ContainsKey("opNoFutureLevel"))
+                    errors.Add($"{kValidationInfoPrefix} Selecting a \"No Future\" level is useless if you don't have \"No Future\" enemy stat growth");
 
                 // Use sensible mana seed settings
                 if ((!optionsCopy.ContainsKey("opGoal") || optionsCopy["opGoal"] != "mtr") && (

--- a/MaraBot/IO/OptionsIO.cs
+++ b/MaraBot/IO/OptionsIO.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace MaraBot.IO
 {

--- a/MaraBot/IO/OptionsIO.cs
+++ b/MaraBot/IO/OptionsIO.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace MaraBot.IO
 {
@@ -41,7 +42,15 @@ namespace MaraBot.IO
             using (StreamReader r = new StreamReader(optionsPath))
             {
                 var json = await r.ReadToEndAsync();
-                return JsonConvert.DeserializeObject<Dictionary<string, Option>>(json);
+                return JsonConvert.DeserializeObject<Dictionary<string, Option>>
+                (
+                    json,
+                    new JsonSerializerSettings
+                    {
+                        TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+                        TypeNameHandling = TypeNameHandling.All,
+                    }
+                );
             }
         }
     }

--- a/config/options.json
+++ b/config/options.json
@@ -1,6 +1,7 @@
 {
+  "$type":"System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[MaraBot.Core.Option, MaraBot]], mscorlib",
   "mode": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Game Mode",
     "mode": "Mode",
     "values": {
@@ -15,7 +16,7 @@
 
 
   "funSpeedup": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Speedup improvements",
     "mode": "General",
     "values": {
@@ -23,7 +24,7 @@
     }
   },
   "mpAtLevel": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "MP Restore at level up",
     "mode": "General",
     "values": {
@@ -31,7 +32,7 @@
     }
   },
   "speciesDamage": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Enemy species damage",
     "mode": "General",
     "values": {
@@ -39,7 +40,7 @@
     }
   },
   "elemDamage": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Elemental melee damage",
     "mode": "General",
     "values": {
@@ -47,7 +48,7 @@
     }
   },
   "offscreenTarget": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Extended targeting",
     "mode": "General",
     "values": {
@@ -55,7 +56,7 @@
     }
   },
   "moreItems": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "7 items max",
     "mode": "General",
     "values": {
@@ -63,7 +64,7 @@
     }
   },
   "leavePlayersBehind": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Allow leaving characters behind",
     "mode": "General",
     "values": {
@@ -71,7 +72,7 @@
     }
   },
   "fasterMagicLevel": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Faster magic levels",
     "mode": "General",
     "values": {
@@ -79,7 +80,7 @@
     }
   },
   "fasterWeaponLevel": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Faster weapon levels",
     "mode": "General",
     "values": {
@@ -87,7 +88,7 @@
     }
   },
   "fasterChests": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Faster chest opening",
     "mode": "General",
     "values": {
@@ -95,7 +96,7 @@
     }
   },
   "fasterMessages": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Faster messages",
     "mode": "General",
     "values": {
@@ -103,7 +104,7 @@
     }
   },
   "buyMultiple": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Buy multiple consumables",
     "mode": "General",
     "values": {
@@ -111,7 +112,7 @@
     }
   },
   "showEvades": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Show evades",
     "mode": "General",
     "values": {
@@ -120,7 +121,7 @@
   },
 
   "ovrchrgFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Overcharge fix",
     "mode": "General",
     "values": {
@@ -128,7 +129,7 @@
     }
   },
   "orbFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Orb reward fix",
     "mode": "General",
     "values": {
@@ -136,7 +137,7 @@
     }
   },
   "bossDeathFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Boss death fix",
     "mode": "General",
     "values": {
@@ -144,7 +145,7 @@
     }
   },
   "whipFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Whip coordinate corruption fix",
     "mode": "General",
     "values": {
@@ -152,7 +153,7 @@
     }
   },
   "noSummonDespawn": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Summoning Despawn Fix",
     "mode": "General",
     "values": {
@@ -160,7 +161,7 @@
     }
   },
   "confusionFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Confusion Fix",
     "mode": "General",
     "values": {
@@ -168,7 +169,7 @@
     }
   },
   "mode7Fix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Mode 7 edges fix",
     "mode": "General",
     "values": {
@@ -176,7 +177,7 @@
     }
   },
   "mechRiderDeathFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Mech rider death fix",
     "mode": "General",
     "values": {
@@ -185,7 +186,7 @@
   },
 
   "aggBosses": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Aggressive bosses",
     "mode": "General",
     "values": {
@@ -193,7 +194,7 @@
     }
   },
   "aggEnemies": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Aggressive enemies",
     "mode": "General",
     "values": {
@@ -201,7 +202,7 @@
     }
   },
   "noBsVampires": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Hittable Vampires",
     "mode": "General",
     "values": {
@@ -209,7 +210,7 @@
     }
   },
   "noGigasSplit": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Gigases don't split",
     "mode": "General",
     "values": {
@@ -217,7 +218,7 @@
     }
   },
   "hittableBeaks": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Beak Shield Disable",
     "mode": "General",
     "values": {
@@ -225,7 +226,7 @@
     }
   },
   "noStaminaRun": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "No stamina cost to run",
     "mode": "General",
     "values": {
@@ -233,7 +234,7 @@
     }
   },
   "adjustEnemyPos": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Enemy position adjustment",
     "mode": "General",
     "values": {
@@ -241,7 +242,7 @@
     }
   },
   "obscureDamage": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Obscure damage",
     "mode": "General",
     "values": {
@@ -249,7 +250,7 @@
     }
   },
   "obscureHp": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Obscure own HP",
     "mode": "General",
     "values": {
@@ -257,7 +258,7 @@
     }
   },
   "obscureGold": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Obscure own gold",
     "mode": "General",
     "values": {
@@ -265,7 +266,7 @@
     }
   },
   "attacksForever": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Attacks don't cost stamina",
     "mode": "General",
     "values": {
@@ -274,7 +275,7 @@
   },
 
   "longStatus": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Status length increase",
     "mode": "General",
     "values": {
@@ -282,7 +283,7 @@
     }
   },
   "magicRebalance": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Magic rebalance",
     "mode": "General",
     "values": {
@@ -290,7 +291,7 @@
     }
   },
   "accuratePercent": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Accurate damage percentages",
     "mode": "General",
     "values": {
@@ -298,7 +299,7 @@
     }
   },
   "manaMagicFix": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Mana Magic change",
     "mode": "General",
     "values": {
@@ -306,7 +307,7 @@
     }
   },
   "percentPoison": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Percentage Damage Poison",
     "mode": "General",
     "values": {
@@ -314,7 +315,7 @@
     }
   },
   "defRefactor": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Defense Refactor",
     "mode": "General",
     "values": {
@@ -322,7 +323,7 @@
     }
   },
   "starterGear": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Starter gear",
     "mode": "General",
     "values": {
@@ -330,7 +331,7 @@
     }
   },
   "bossFixedZ": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Bosses at Fixed Z Position",
     "mode": "General",
     "values": {
@@ -339,7 +340,7 @@
   },
 
   "statusGlow": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Status glow",
     "mode": "General",
     "values": {
@@ -347,7 +348,7 @@
     }
   },
   "seReduction": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Sound effects reduction",
     "mode": "General",
     "values": {
@@ -355,7 +356,7 @@
     }
   },
   "rainbowRabites": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Random Rabite colors",
     "mode": "General",
     "values": {
@@ -363,7 +364,7 @@
     }
   },
   "fastTransition": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Fast transitions",
     "mode": "General",
     "values": {
@@ -371,7 +372,7 @@
     }
   },
   "muteMusic": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Mute all music",
     "mode": "General",
     "values": {
@@ -379,7 +380,7 @@
     }
   },
   "characterColors": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Character colors",
     "mode": "General",
     "values": {
@@ -389,7 +390,7 @@
   },
 
   "bossElementRando": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize Boss Elements",
     "mode": "General",
     "values": {
@@ -398,7 +399,7 @@
   },
 
   "ohko": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "One-hit KO",
     "mode": "General",
     "values": {
@@ -406,7 +407,7 @@
     }
   },
   "noclip": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Walk through walls",
     "mode": "General",
     "values": {
@@ -414,7 +415,7 @@
     }
   },
   "deathByPoison": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Poisoned players",
     "mode": "General",
     "values": {
@@ -425,7 +426,7 @@
 
 
   "rBosses": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize bosses",
     "mode": "Rando",
     "values": {
@@ -433,7 +434,7 @@
     }
   },
   "rEnemies": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize non-boss enemies",
     "mode": "Rando",
     "values": {
@@ -441,7 +442,7 @@
     }
   },
   "rOrbs": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize weapon orbs",
     "mode": "Rando",
     "values": {
@@ -449,7 +450,7 @@
     }
   },
   "rElements": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize elements",
     "mode": "Rando",
     "values": {
@@ -457,7 +458,7 @@
     }
   },
   "rWeapons": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize weapons",
     "mode": "Rando",
     "values": {
@@ -465,7 +466,7 @@
     }
   },
   "rMusic": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize music",
     "mode": "Rando",
     "values": {
@@ -473,7 +474,7 @@
     }
   },
   "rDialogue": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Shorter dialogue",
     "mode": "Rando",
     "values": {
@@ -481,7 +482,7 @@
     }
   },
   "rAutosave": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Autosave",
     "mode": "Rando",
     "values": {
@@ -489,7 +490,7 @@
     }
   },
   "rPreserve": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Preserve early bosses",
     "mode": "Rando",
     "values": {
@@ -497,7 +498,7 @@
     }
   },
   "rExp": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Experience",
     "mode": "Rando",
     "values": {
@@ -507,7 +508,7 @@
     }
   },
   "rGold": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Gold",
     "mode": "Rando",
     "values": {
@@ -517,7 +518,7 @@
     }
   },
   "rStatusAilments": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Status ailments",
     "mode": "Rando",
     "values": {
@@ -528,7 +529,7 @@
     }
   },
   "rHoliday": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Special mode",
     "mode": "Rando",
     "values": {
@@ -537,7 +538,7 @@
     }
   },
   "rDifficulty": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Enemy difficulty",
     "mode": "Rando",
     "values": {
@@ -555,7 +556,7 @@
 
 
   "opWeapons": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize weapons",
     "mode": "Open",
     "values": {
@@ -563,7 +564,7 @@
     }
   },
   "opMusic": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize music",
     "mode": "Open",
     "values": {
@@ -571,7 +572,7 @@
     }
   },
   "opShop": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize shops",
     "mode": "Open",
     "values": {
@@ -579,7 +580,7 @@
     }
   },
   "opMapColors": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize map colors",
     "mode": "Open",
     "values": {
@@ -587,7 +588,7 @@
     }
   },
   "opStartChar": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Start char",
     "mode": "Open",
     "values": {
@@ -597,7 +598,7 @@
     }
   },
   "opBosses": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Bosses",
     "mode": "Open",
     "values": {
@@ -606,7 +607,7 @@
     }
   },
   "opEnemies": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Enemies",
     "mode": "Open",
     "values": {
@@ -617,7 +618,7 @@
     }
   },
   "opGoal": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Goal",
     "mode": "Open",
     "values": {
@@ -628,7 +629,7 @@
     }
   },
   "opLogic": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Logic",
     "mode": "Open",
     "values": {
@@ -636,7 +637,7 @@
     }
   },
   "opStatGrowth": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Enemy stat growth",
     "mode": "Open",
     "values": {
@@ -646,7 +647,7 @@
     }
   },
   "opDifficulty": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Difficulty",
     "mode": "Open",
     "values": {
@@ -658,7 +659,7 @@
     }
   },
   "opCharacters": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Other chars",
     "mode": "Open",
     "values": {
@@ -672,7 +673,7 @@
     }
   },
   "opExp": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Experience",
     "mode": "Open",
     "values": {
@@ -682,7 +683,7 @@
     }
   },
   "opGold": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Gold",
     "mode": "Open",
     "values": {
@@ -692,7 +693,7 @@
     }
   },
   "opStatusAilments": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Status ailments",
     "mode": "Open",
     "values": {
@@ -704,7 +705,7 @@
   },
 
   "opComplexity": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Complexity",
     "mode": "Open",
     "values": {
@@ -713,7 +714,7 @@
     }
   },
   "opManaBeastScale": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Mana Beast Stats",
     "mode": "Open",
     "values": {
@@ -721,7 +722,7 @@
     }
   },
   "opTraps": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Chest traps",
     "mode": "Open",
     "values": {
@@ -730,7 +731,7 @@
     }
   },
   "opChestFreq": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Chest drop frequency",
     "mode": "Open",
     "values": {
@@ -741,7 +742,7 @@
     }
   },
   "opXmasItems": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Random drops",
     "mode": "Open",
     "values": {
@@ -749,7 +750,7 @@
     }
   },
   "opMinLevel": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Minimum enemy level",
     "mode": "Open",
     "values": {
@@ -757,7 +758,7 @@
     }
   },
   "opMaxLevel": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Maximum enemy level",
     "mode": "Open",
     "values": {
@@ -765,7 +766,7 @@
     }
   },
   "opDisableHints": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Disable hints",
     "mode": "Open",
     "values": {
@@ -773,7 +774,7 @@
     }
   },
   "opPlatinumMode": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Black out map data",
     "mode": "Open",
     "values": {
@@ -782,7 +783,7 @@
   },
 
   "opBoyRole": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Boy character role",
     "mode": "Open",
     "values": {
@@ -794,7 +795,7 @@
     }
   },
   "opGirlRole": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Girl character role",
     "mode": "Open",
     "values": {
@@ -806,7 +807,7 @@
     }
   },
   "opSpriteRole": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Sprite character role",
     "mode": "Open",
     "values": {
@@ -819,7 +820,7 @@
   },
 
   "opNumSeeds": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Mana Tree Revival seeds required",
     "mode": "Open",
     "values": {
@@ -834,7 +835,7 @@
     }
   },
   "opMinSeeds": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Minimum Mana Tree Revival seeds required",
     "mode": "Open",
     "values": {
@@ -848,7 +849,7 @@
     }
   },
   "opMaxSeeds": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Maximum Mana Tree Revival seeds required",
     "mode": "Open",
     "values": {
@@ -863,7 +864,7 @@
   },
 
   "opShowLevels": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Show enemy level",
     "mode": "Open",
     "values": {
@@ -871,7 +872,7 @@
     }
   },
   "opAutosave": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Autosave",
     "mode": "Open",
     "values": {
@@ -879,7 +880,7 @@
     }
   },
   "opMagicRopeRefactor": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Magic Rope Refactor",
     "mode": "Open",
     "values": {
@@ -887,7 +888,7 @@
     }
   },
   "oopsAllThis": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "But why owls?",
     "mode": "Open",
     "values": {
@@ -979,7 +980,7 @@
     }
   },
   "opStartWeapon": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Force starting weapon",
     "mode": "Open",
     "values": {
@@ -994,7 +995,7 @@
     }
   },
   "opChestsDontRun": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Chests don't run away",
     "mode": "Open",
     "values": {
@@ -1002,7 +1003,7 @@
     }
   },
   "opAiRando": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Enemy AI mode",
     "mode": "Open",
     "values": {
@@ -1010,7 +1011,7 @@
     }
   },
   "opPauseInMenu": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Pause timer in menu",
     "mode": "Open",
     "values": {
@@ -1018,7 +1019,7 @@
     }
   },
   "opXmasMaps": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Christmas theme",
     "mode": "Open",
     "values": {
@@ -1026,7 +1027,7 @@
     }
   },
   "opGPEleRando": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Randomize Grand Palace elements",
     "mode": "Open",
     "values": {
@@ -1034,7 +1035,7 @@
     }
   },
   "opAllowLockedItems": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Allow locked items",
     "mode": "Open",
     "values": {
@@ -1042,7 +1043,7 @@
     }
   },
   "opSpoilerLog": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Spoiler log",
     "mode": "Open",
     "values": {
@@ -1050,7 +1051,7 @@
     }
   },
   "opAllWeaponOrbs": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Start with all weapon orbs",
     "mode": "Open",
     "values": {
@@ -1061,7 +1062,7 @@
 
 
   "acDifficulty": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Difficulty",
     "mode": "AncientCave",
     "values": {
@@ -1071,7 +1072,7 @@
     }
   },
   "acDialogue": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "NPC Dialogue",
     "mode": "AncientCave",
     "values": {
@@ -1079,7 +1080,7 @@
     }
   },
   "acFilter": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Dialogue language filter",
     "mode": "AncientCave",
     "values": {
@@ -1087,7 +1088,7 @@
     }
   },
   "acMusic": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Random music",
     "mode": "AncientCave",
     "values": {
@@ -1095,7 +1096,7 @@
     }
   },
   "acBoy": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Boy",
     "mode": "AncientCave",
     "values": {
@@ -1103,7 +1104,7 @@
     }
   },
   "acGirl": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Girl",
     "mode": "AncientCave",
     "values": {
@@ -1111,7 +1112,7 @@
     }
   },
   "acSprite": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Sprite",
     "mode": "AncientCave",
     "values": {
@@ -1119,7 +1120,7 @@
     }
   },
   "acLength": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Length",
     "mode": "AncientCave",
     "values": {
@@ -1128,7 +1129,7 @@
     }
   },
   "acBosses": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Bosses",
     "mode": "AncientCave",
     "values": {
@@ -1137,7 +1138,7 @@
     }
   },
   "acBiomeTypes": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Floor Types",
     "mode": "AncientCave",
     "list": true,
@@ -1153,7 +1154,7 @@
 
 
   "brDifficulty": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Difficulty",
     "mode": "BossRush",
     "values": {
@@ -1163,7 +1164,7 @@
     }
   },
   "brBoy": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Boy",
     "mode": "BossRush",
     "values": {
@@ -1171,7 +1172,7 @@
     }
   },
   "brGirl": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Girl",
     "mode": "BossRush",
     "values": {
@@ -1179,7 +1180,7 @@
     }
   },
   "brSprite": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Sprite",
     "mode": "BossRush",
     "values": {
@@ -1187,7 +1188,7 @@
     }
   },
   "brLimitMpAbsorb": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Limit MP Absorb",
     "mode": "BossRush",
     "values": {
@@ -1198,7 +1199,7 @@
 
 
   "chDifficulty": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Difficulty",
     "mode": "Chaos",
     "values": {
@@ -1208,7 +1209,7 @@
     }
   },
   "chBoy": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Boy",
     "mode": "Chaos",
     "values": {
@@ -1216,7 +1217,7 @@
     }
   },
   "chGirl": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Girl",
     "mode": "Chaos",
     "values": {
@@ -1224,7 +1225,7 @@
     }
   },
   "chSprite": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Sprite",
     "mode": "Chaos",
     "values": {
@@ -1232,7 +1233,7 @@
     }
   },
   "chFloors": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Length",
     "mode": "Chaos",
     "values": {
@@ -1243,7 +1244,7 @@
     }
   },
   "chBosses": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Bosses",
     "mode": "Chaos",
     "values": {
@@ -1254,7 +1255,7 @@
     }
   },
   "chMapColors": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Color randomization",
     "mode": "Chaos",
     "values": {
@@ -1263,7 +1264,7 @@
     }
   },
   "chHealSpellsFirst": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Prioritize heal spells",
     "mode": "Chaos",
     "values": {
@@ -1271,7 +1272,7 @@
     }
   },
   "chEasyEarlyFloors": {
-    "$type": "MaraBot.Core.EnumOption",
+    "$type": "MaraBot.Core.EnumOption, MaraBot",
     "name": "Safer early floors",
     "mode": "Chaos",
     "values": {

--- a/config/options.json
+++ b/config/options.json
@@ -1,5 +1,6 @@
 {
   "mode": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Game Mode",
     "mode": "Mode",
     "values": {
@@ -14,6 +15,7 @@
 
 
   "funSpeedup": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Speedup improvements",
     "mode": "General",
     "values": {
@@ -21,6 +23,7 @@
     }
   },
   "mpAtLevel": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "MP Restore at level up",
     "mode": "General",
     "values": {
@@ -28,6 +31,7 @@
     }
   },
   "speciesDamage": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Enemy species damage",
     "mode": "General",
     "values": {
@@ -35,6 +39,7 @@
     }
   },
   "elemDamage": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Elemental melee damage",
     "mode": "General",
     "values": {
@@ -42,6 +47,7 @@
     }
   },
   "offscreenTarget": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Extended targeting",
     "mode": "General",
     "values": {
@@ -49,6 +55,7 @@
     }
   },
   "moreItems": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "7 items max",
     "mode": "General",
     "values": {
@@ -56,6 +63,7 @@
     }
   },
   "leavePlayersBehind": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Allow leaving characters behind",
     "mode": "General",
     "values": {
@@ -63,6 +71,7 @@
     }
   },
   "fasterMagicLevel": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Faster magic levels",
     "mode": "General",
     "values": {
@@ -70,6 +79,7 @@
     }
   },
   "fasterWeaponLevel": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Faster weapon levels",
     "mode": "General",
     "values": {
@@ -77,6 +87,7 @@
     }
   },
   "fasterChests": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Faster chest opening",
     "mode": "General",
     "values": {
@@ -84,6 +95,7 @@
     }
   },
   "fasterMessages": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Faster messages",
     "mode": "General",
     "values": {
@@ -91,6 +103,7 @@
     }
   },
   "buyMultiple": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Buy multiple consumables",
     "mode": "General",
     "values": {
@@ -98,14 +111,16 @@
     }
   },
   "showEvades": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Show evades",
     "mode": "General",
     "values": {
       "no": "No"
     }
   },
-  
+
   "ovrchrgFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Overcharge fix",
     "mode": "General",
     "values": {
@@ -113,6 +128,7 @@
     }
   },
   "orbFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Orb reward fix",
     "mode": "General",
     "values": {
@@ -120,6 +136,7 @@
     }
   },
   "bossDeathFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Boss death fix",
     "mode": "General",
     "values": {
@@ -127,6 +144,7 @@
     }
   },
   "whipFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Whip coordinate corruption fix",
     "mode": "General",
     "values": {
@@ -134,6 +152,7 @@
     }
   },
   "noSummonDespawn": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Summoning Despawn Fix",
     "mode": "General",
     "values": {
@@ -141,6 +160,7 @@
     }
   },
   "confusionFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Confusion Fix",
     "mode": "General",
     "values": {
@@ -148,6 +168,7 @@
     }
   },
   "mode7Fix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Mode 7 edges fix",
     "mode": "General",
     "values": {
@@ -155,14 +176,16 @@
     }
   },
   "mechRiderDeathFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Mech rider death fix",
     "mode": "General",
     "values": {
       "no": "No"
     }
   },
-  
+
   "aggBosses": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Aggressive bosses",
     "mode": "General",
     "values": {
@@ -170,6 +193,7 @@
     }
   },
   "aggEnemies": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Aggressive enemies",
     "mode": "General",
     "values": {
@@ -177,6 +201,7 @@
     }
   },
   "noBsVampires": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Hittable Vampires",
     "mode": "General",
     "values": {
@@ -184,6 +209,7 @@
     }
   },
   "noGigasSplit": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Gigases don't split",
     "mode": "General",
     "values": {
@@ -191,6 +217,7 @@
     }
   },
   "hittableBeaks": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Beak Shield Disable",
     "mode": "General",
     "values": {
@@ -198,6 +225,7 @@
     }
   },
   "noStaminaRun": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "No stamina cost to run",
     "mode": "General",
     "values": {
@@ -205,6 +233,7 @@
     }
   },
   "adjustEnemyPos": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Enemy position adjustment",
     "mode": "General",
     "values": {
@@ -212,6 +241,7 @@
     }
   },
   "obscureDamage": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Obscure damage",
     "mode": "General",
     "values": {
@@ -219,6 +249,7 @@
     }
   },
   "obscureHp": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Obscure own HP",
     "mode": "General",
     "values": {
@@ -226,6 +257,7 @@
     }
   },
   "obscureGold": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Obscure own gold",
     "mode": "General",
     "values": {
@@ -233,14 +265,16 @@
     }
   },
   "attacksForever": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Attacks don't cost stamina",
     "mode": "General",
     "values": {
       "yes": "Yes"
     }
   },
-  
+
   "longStatus": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Status length increase",
     "mode": "General",
     "values": {
@@ -248,6 +282,7 @@
     }
   },
   "magicRebalance": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Magic rebalance",
     "mode": "General",
     "values": {
@@ -255,6 +290,7 @@
     }
   },
   "accuratePercent": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Accurate damage percentages",
     "mode": "General",
     "values": {
@@ -262,6 +298,7 @@
     }
   },
   "manaMagicFix": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Mana Magic change",
     "mode": "General",
     "values": {
@@ -269,6 +306,7 @@
     }
   },
   "percentPoison": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Percentage Damage Poison",
     "mode": "General",
     "values": {
@@ -276,6 +314,7 @@
     }
   },
   "defRefactor": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Defense Refactor",
     "mode": "General",
     "values": {
@@ -283,6 +322,7 @@
     }
   },
   "starterGear": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Starter gear",
     "mode": "General",
     "values": {
@@ -290,14 +330,16 @@
     }
   },
   "bossFixedZ": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Bosses at Fixed Z Position",
     "mode": "General",
     "values": {
       "yes": "Yes"
     }
   },
-  
+
   "statusGlow": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Status glow",
     "mode": "General",
     "values": {
@@ -305,6 +347,7 @@
     }
   },
   "seReduction": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Sound effects reduction",
     "mode": "General",
     "values": {
@@ -312,6 +355,7 @@
     }
   },
   "rainbowRabites": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Random Rabite colors",
     "mode": "General",
     "values": {
@@ -319,6 +363,7 @@
     }
   },
   "fastTransition": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Fast transitions",
     "mode": "General",
     "values": {
@@ -326,6 +371,7 @@
     }
   },
   "muteMusic": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Mute all music",
     "mode": "General",
     "values": {
@@ -333,6 +379,7 @@
     }
   },
   "characterColors": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Character colors",
     "mode": "General",
     "values": {
@@ -340,16 +387,18 @@
       "custom": "Custom (Specify...)"
     }
   },
-  
+
   "bossElementRando": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize Boss Elements",
     "mode": "General",
     "values": {
       "yes": "Yes"
     }
   },
-  
+
   "ohko": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "One-hit KO",
     "mode": "General",
     "values": {
@@ -357,6 +406,7 @@
     }
   },
   "noclip": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Walk through walls",
     "mode": "General",
     "values": {
@@ -364,6 +414,7 @@
     }
   },
   "deathByPoison": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Poisoned players",
     "mode": "General",
     "values": {
@@ -374,6 +425,7 @@
 
 
   "rBosses": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize bosses",
     "mode": "Rando",
     "values": {
@@ -381,6 +433,7 @@
     }
   },
   "rEnemies": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize non-boss enemies",
     "mode": "Rando",
     "values": {
@@ -388,6 +441,7 @@
     }
   },
   "rOrbs": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize weapon orbs",
     "mode": "Rando",
     "values": {
@@ -395,6 +449,7 @@
     }
   },
   "rElements": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize elements",
     "mode": "Rando",
     "values": {
@@ -402,6 +457,7 @@
     }
   },
   "rWeapons": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize weapons",
     "mode": "Rando",
     "values": {
@@ -409,6 +465,7 @@
     }
   },
   "rMusic": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize music",
     "mode": "Rando",
     "values": {
@@ -416,6 +473,7 @@
     }
   },
   "rDialogue": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Shorter dialogue",
     "mode": "Rando",
     "values": {
@@ -423,6 +481,7 @@
     }
   },
   "rAutosave": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Autosave",
     "mode": "Rando",
     "values": {
@@ -430,6 +489,7 @@
     }
   },
   "rPreserve": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Preserve early bosses",
     "mode": "Rando",
     "values": {
@@ -437,6 +497,7 @@
     }
   },
   "rExp": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Experience",
     "mode": "Rando",
     "values": {
@@ -446,6 +507,7 @@
     }
   },
   "rGold": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Gold",
     "mode": "Rando",
     "values": {
@@ -455,6 +517,7 @@
     }
   },
   "rStatusAilments": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Status ailments",
     "mode": "Rando",
     "values": {
@@ -465,6 +528,7 @@
     }
   },
   "rHoliday": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Special mode",
     "mode": "Rando",
     "values": {
@@ -473,6 +537,7 @@
     }
   },
   "rDifficulty": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Enemy difficulty",
     "mode": "Rando",
     "values": {
@@ -490,6 +555,7 @@
 
 
   "opWeapons": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize weapons",
     "mode": "Open",
     "values": {
@@ -497,6 +563,7 @@
     }
   },
   "opMusic": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize music",
     "mode": "Open",
     "values": {
@@ -504,6 +571,7 @@
     }
   },
   "opShop": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize shops",
     "mode": "Open",
     "values": {
@@ -511,6 +579,7 @@
     }
   },
   "opMapColors": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize map colors",
     "mode": "Open",
     "values": {
@@ -518,6 +587,7 @@
     }
   },
   "opStartChar": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Start char",
     "mode": "Open",
     "values": {
@@ -527,6 +597,7 @@
     }
   },
   "opBosses": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Bosses",
     "mode": "Open",
     "values": {
@@ -535,6 +606,7 @@
     }
   },
   "opEnemies": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Enemies",
     "mode": "Open",
     "values": {
@@ -545,6 +617,7 @@
     }
   },
   "opGoal": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Goal",
     "mode": "Open",
     "values": {
@@ -555,6 +628,7 @@
     }
   },
   "opLogic": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Logic",
     "mode": "Open",
     "values": {
@@ -562,6 +636,7 @@
     }
   },
   "opStatGrowth": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Enemy stat growth",
     "mode": "Open",
     "values": {
@@ -571,6 +646,7 @@
     }
   },
   "opDifficulty": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Difficulty",
     "mode": "Open",
     "values": {
@@ -582,6 +658,7 @@
     }
   },
   "opCharacters": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Other chars",
     "mode": "Open",
     "values": {
@@ -595,6 +672,7 @@
     }
   },
   "opExp": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Experience",
     "mode": "Open",
     "values": {
@@ -604,6 +682,7 @@
     }
   },
   "opGold": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Gold",
     "mode": "Open",
     "values": {
@@ -613,6 +692,7 @@
     }
   },
   "opStatusAilments": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Status ailments",
     "mode": "Open",
     "values": {
@@ -622,8 +702,9 @@
       "awful"   : "Random (awful)"
     }
   },
-  
+
   "opComplexity": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Complexity",
     "mode": "Open",
     "values": {
@@ -632,6 +713,7 @@
     }
   },
   "opManaBeastScale": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Mana Beast Stats",
     "mode": "Open",
     "values": {
@@ -639,6 +721,7 @@
     }
   },
   "opTraps": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Chest traps",
     "mode": "Open",
     "values": {
@@ -647,6 +730,7 @@
     }
   },
   "opChestFreq": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Chest drop frequency",
     "mode": "Open",
     "values": {
@@ -657,6 +741,7 @@
     }
   },
   "opXmasItems": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Random drops",
     "mode": "Open",
     "values": {
@@ -664,6 +749,7 @@
     }
   },
   "opMinLevel": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Minimum enemy level",
     "mode": "Open",
     "values": {
@@ -671,6 +757,7 @@
     }
   },
   "opMaxLevel": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Maximum enemy level",
     "mode": "Open",
     "values": {
@@ -678,6 +765,7 @@
     }
   },
   "opDisableHints": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Disable hints",
     "mode": "Open",
     "values": {
@@ -685,14 +773,16 @@
     }
   },
   "opPlatinumMode": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Black out map data",
     "mode": "Open",
     "values": {
       "yes": "Yes"
     }
   },
-  
+
   "opBoyRole": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Boy character role",
     "mode": "Open",
     "values": {
@@ -704,6 +794,7 @@
     }
   },
   "opGirlRole": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Girl character role",
     "mode": "Open",
     "values": {
@@ -715,6 +806,7 @@
     }
   },
   "opSpriteRole": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Sprite character role",
     "mode": "Open",
     "values": {
@@ -725,8 +817,9 @@
       "ogsprite"      : "Sprite"
     }
   },
-  
+
   "opNumSeeds": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Mana Tree Revival seeds required",
     "mode": "Open",
     "values": {
@@ -741,6 +834,7 @@
     }
   },
   "opMinSeeds": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Minimum Mana Tree Revival seeds required",
     "mode": "Open",
     "values": {
@@ -754,6 +848,7 @@
     }
   },
   "opMaxSeeds": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Maximum Mana Tree Revival seeds required",
     "mode": "Open",
     "values": {
@@ -766,8 +861,9 @@
       "7": "7"
     }
   },
-  
+
   "opShowLevels": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Show enemy level",
     "mode": "Open",
     "values": {
@@ -775,6 +871,7 @@
     }
   },
   "opAutosave": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Autosave",
     "mode": "Open",
     "values": {
@@ -782,6 +879,7 @@
     }
   },
   "opMagicRopeRefactor": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Magic Rope Refactor",
     "mode": "Open",
     "values": {
@@ -789,6 +887,7 @@
     }
   },
   "oopsAllThis": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "But why owls?",
     "mode": "Open",
     "values": {
@@ -880,6 +979,7 @@
     }
   },
   "opStartWeapon": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Force starting weapon",
     "mode": "Open",
     "values": {
@@ -894,6 +994,7 @@
     }
   },
   "opChestsDontRun": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Chests don't run away",
     "mode": "Open",
     "values": {
@@ -901,6 +1002,7 @@
     }
   },
   "opAiRando": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Enemy AI mode",
     "mode": "Open",
     "values": {
@@ -908,6 +1010,7 @@
     }
   },
   "opPauseInMenu": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Pause timer in menu",
     "mode": "Open",
     "values": {
@@ -915,6 +1018,7 @@
     }
   },
   "opXmasMaps": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Christmas theme",
     "mode": "Open",
     "values": {
@@ -922,6 +1026,7 @@
     }
   },
   "opGPEleRando": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Randomize Grand Palace elements",
     "mode": "Open",
     "values": {
@@ -929,6 +1034,7 @@
     }
   },
   "opAllowLockedItems": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Allow locked items",
     "mode": "Open",
     "values": {
@@ -936,6 +1042,7 @@
     }
   },
   "opSpoilerLog": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Spoiler log",
     "mode": "Open",
     "values": {
@@ -943,6 +1050,7 @@
     }
   },
   "opAllWeaponOrbs": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Start with all weapon orbs",
     "mode": "Open",
     "values": {
@@ -953,6 +1061,7 @@
 
 
   "acDifficulty": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Difficulty",
     "mode": "AncientCave",
     "values": {
@@ -962,6 +1071,7 @@
     }
   },
   "acDialogue": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "NPC Dialogue",
     "mode": "AncientCave",
     "values": {
@@ -969,6 +1079,7 @@
     }
   },
   "acFilter": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Dialogue language filter",
     "mode": "AncientCave",
     "values": {
@@ -976,6 +1087,7 @@
     }
   },
   "acMusic": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Random music",
     "mode": "AncientCave",
     "values": {
@@ -983,6 +1095,7 @@
     }
   },
   "acBoy": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Boy",
     "mode": "AncientCave",
     "values": {
@@ -990,6 +1103,7 @@
     }
   },
   "acGirl": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Girl",
     "mode": "AncientCave",
     "values": {
@@ -997,6 +1111,7 @@
     }
   },
   "acSprite": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Sprite",
     "mode": "AncientCave",
     "values": {
@@ -1004,6 +1119,7 @@
     }
   },
   "acLength": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Length",
     "mode": "AncientCave",
     "values": {
@@ -1012,6 +1128,7 @@
     }
   },
   "acBosses": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Bosses",
     "mode": "AncientCave",
     "values": {
@@ -1020,9 +1137,10 @@
     }
   },
   "acBiomeTypes": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Floor Types",
     "mode": "AncientCave",
-    "type": "List",
+    "list": true,
     "values": {
       "forest"          : "Forest",
       "island"          : "Island",
@@ -1035,6 +1153,7 @@
 
 
   "brDifficulty": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Difficulty",
     "mode": "BossRush",
     "values": {
@@ -1044,6 +1163,7 @@
     }
   },
   "brBoy": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Boy",
     "mode": "BossRush",
     "values": {
@@ -1051,6 +1171,7 @@
     }
   },
   "brGirl": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Girl",
     "mode": "BossRush",
     "values": {
@@ -1058,6 +1179,7 @@
     }
   },
   "brSprite": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Sprite",
     "mode": "BossRush",
     "values": {
@@ -1065,6 +1187,7 @@
     }
   },
   "brLimitMpAbsorb": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Limit MP Absorb",
     "mode": "BossRush",
     "values": {
@@ -1075,6 +1198,7 @@
 
 
   "chDifficulty": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Difficulty",
     "mode": "Chaos",
     "values": {
@@ -1084,6 +1208,7 @@
     }
   },
   "chBoy": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Boy",
     "mode": "Chaos",
     "values": {
@@ -1091,6 +1216,7 @@
     }
   },
   "chGirl": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Girl",
     "mode": "Chaos",
     "values": {
@@ -1098,6 +1224,7 @@
     }
   },
   "chSprite": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Sprite",
     "mode": "Chaos",
     "values": {
@@ -1105,6 +1232,7 @@
     }
   },
   "chFloors": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Length",
     "mode": "Chaos",
     "values": {
@@ -1115,6 +1243,7 @@
     }
   },
   "chBosses": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Bosses",
     "mode": "Chaos",
     "values": {
@@ -1125,6 +1254,7 @@
     }
   },
   "chMapColors": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Color randomization",
     "mode": "Chaos",
     "values": {
@@ -1133,6 +1263,7 @@
     }
   },
   "chHealSpellsFirst": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Prioritize heal spells",
     "mode": "Chaos",
     "values": {
@@ -1140,6 +1271,7 @@
     }
   },
   "chEasyEarlyFloors": {
+    "$type": "MaraBot.Core.EnumOption",
     "name": "Safer early floors",
     "mode": "Chaos",
     "values": {

--- a/config/options.json
+++ b/config/options.json
@@ -1,9 +1,12 @@
 {
   "$type":"System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[MaraBot.Core.Option, MaraBot]], mscorlib",
+
+
+
   "mode": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Game Mode",
-    "mode": "Mode",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Game Mode",
+    "mode"  : "Mode",
     "values": {
       "rando"      : "Rando"       ,
       "open"       : "Open World"  ,
@@ -16,373 +19,373 @@
 
 
   "funSpeedup": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Speedup improvements",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Speedup improvements",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "mpAtLevel": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "MP Restore at level up",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "MP Restore at level up",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "speciesDamage": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Enemy species damage",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Enemy species damage",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "elemDamage": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Elemental melee damage",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Elemental melee damage",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "offscreenTarget": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Extended targeting",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Extended targeting",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "moreItems": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "7 items max",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "7 items max",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "leavePlayersBehind": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Allow leaving characters behind",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Allow leaving characters behind",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "fasterMagicLevel": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Faster magic levels",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Faster magic levels",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "fasterWeaponLevel": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Faster weapon levels",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Faster weapon levels",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "fasterChests": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Faster chest opening",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Faster chest opening",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "fasterMessages": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Faster messages",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Faster messages",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "buyMultiple": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Buy multiple consumables",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Buy multiple consumables",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "showEvades": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Show evades",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Show evades",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
 
   "ovrchrgFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Overcharge fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Overcharge fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "orbFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Orb reward fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Orb reward fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "bossDeathFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Boss death fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Boss death fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "whipFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Whip coordinate corruption fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Whip coordinate corruption fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "noSummonDespawn": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Summoning Despawn Fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Summoning Despawn Fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "confusionFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Confusion Fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Confusion Fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "mode7Fix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Mode 7 edges fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Mode 7 edges fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "mechRiderDeathFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Mech rider death fix",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Mech rider death fix",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
 
   "aggBosses": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Aggressive bosses",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Aggressive bosses",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "aggEnemies": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Aggressive enemies",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Aggressive enemies",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "noBsVampires": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Hittable Vampires",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Hittable Vampires",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "noGigasSplit": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Gigases don't split",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Gigases don't split",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "hittableBeaks": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Beak Shield Disable",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Beak Shield Disable",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "noStaminaRun": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "No stamina cost to run",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "No stamina cost to run",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "adjustEnemyPos": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Enemy position adjustment",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Enemy position adjustment",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "obscureDamage": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Obscure damage",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Obscure damage",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "obscureHp": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Obscure own HP",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Obscure own HP",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "obscureGold": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Obscure own gold",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Obscure own gold",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "attacksForever": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Attacks don't cost stamina",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Attacks don't cost stamina",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
 
   "longStatus": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Status length increase",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Status length increase",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "magicRebalance": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Magic rebalance",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Magic rebalance",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "accuratePercent": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Accurate damage percentages",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Accurate damage percentages",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "manaMagicFix": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Mana Magic change",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Mana Magic change",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "percentPoison": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Percentage Damage Poison",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Percentage Damage Poison",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "defRefactor": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Defense Refactor",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Defense Refactor",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "starterGear": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Starter gear",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Starter gear",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "bossFixedZ": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Bosses at Fixed Z Position",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Bosses at Fixed Z Position",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
 
   "statusGlow": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Status glow",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Status glow",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "seReduction": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Sound effects reduction",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Sound effects reduction",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "rainbowRabites": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Random Rabite colors",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Random Rabite colors",
+    "mode"  : "General",
     "values": {
       "no": "No"
     }
   },
   "fastTransition": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Fast transitions",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Fast transitions",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "muteMusic": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Mute all music",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Mute all music",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "characterColors": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Character colors",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Character colors",
+    "mode"  : "General",
     "values": {
       "none"  : "No change",
       "custom": "Custom (Specify...)"
@@ -390,34 +393,34 @@
   },
 
   "bossElementRando": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize Boss Elements",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize Boss Elements",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
 
   "ohko": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "One-hit KO",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "One-hit KO",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "noclip": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Walk through walls",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Walk through walls",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
   },
   "deathByPoison": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Poisoned players",
-    "mode": "General",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Poisoned players",
+    "mode"  : "General",
     "values": {
       "yes": "Yes"
     }
@@ -426,81 +429,81 @@
 
 
   "rBosses": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize bosses",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize bosses",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rEnemies": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize non-boss enemies",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize non-boss enemies",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rOrbs": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize weapon orbs",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize weapon orbs",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rElements": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize elements",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize elements",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rWeapons": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize weapons",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize weapons",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rMusic": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize music",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize music",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rDialogue": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Shorter dialogue",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Shorter dialogue",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rAutosave": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Autosave",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Autosave",
+    "mode"  : "Rando",
     "values": {
       "no": "No"
     }
   },
   "rPreserve": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Preserve early bosses",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Preserve early bosses",
+    "mode"  : "Rando",
     "values": {
       "yes": "Yes"
     }
   },
   "rExp": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Experience",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Experience",
+    "mode"  : "Rando",
     "values": {
       "half"  : "Half",
       "normal": "Normal",
@@ -508,9 +511,9 @@
     }
   },
   "rGold": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Gold",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Gold",
+    "mode"  : "Rando",
     "values": {
       "half"  : "Half",
       "normal": "Normal",
@@ -518,9 +521,9 @@
     }
   },
   "rStatusAilments": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Status ailments",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Status ailments",
+    "mode"  : "Rando",
     "values": {
       "type"    : "Enemy type",
       "easy"    : "Random (easy)",
@@ -529,18 +532,18 @@
     }
   },
   "rHoliday": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Special mode",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Special mode",
+    "mode"  : "Rando",
     "values": {
       "halloween": "Halloween",
       "xmas"     : "Christmas"
     }
   },
   "rDifficulty": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Enemy difficulty",
-    "mode": "Rando",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Enemy difficulty",
+    "mode"  : "Rando",
     "values": {
       "20" : "Easiest [20%]",
       "40" : "Easier [40%]",
@@ -556,41 +559,41 @@
 
 
   "opWeapons": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize weapons",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize weapons",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opMusic": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize music",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize music",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opShop": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize shops",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize shops",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opMapColors": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize map colors",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize map colors",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opStartChar": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Start char",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Start char",
+    "mode"  : "Open",
     "values": {
       "random": "Random",
       "girl"  : "Girl",
@@ -598,18 +601,18 @@
     }
   },
   "opBosses": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Bosses",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Bosses",
+    "mode"  : "Open",
     "values": {
       "vanilla": "Vanilla",
       "swap"   : "Swap"
     }
   },
   "opEnemies": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Enemies",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Enemies",
+    "mode"  : "Open",
     "values": {
       "vanilla": "Vanilla",
       "random" : "Random spawns",
@@ -618,9 +621,9 @@
     }
   },
   "opGoal": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Goal",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Goal",
+    "mode"  : "Open",
     "values": {
       "vlong": "Vanilla long",
       "mtr": "Mana tree revival",
@@ -629,17 +632,17 @@
     }
   },
   "opLogic": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Logic",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Logic",
+    "mode"  : "Open",
     "values": {
       "restrictive": "Restrictive"
     }
   },
   "opStatGrowth": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Enemy stat growth",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Enemy stat growth",
+    "mode"  : "Open",
     "values": {
       "boss"  : "Increase after bosses",
       "timed"  : "Timed",
@@ -647,9 +650,9 @@
     }
   },
   "opDifficulty": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Difficulty",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Difficulty",
+    "mode"  : "Open",
     "values": {
       "easy"      : "Easy",
       "sortaeasy" : "Sorta easy",
@@ -659,9 +662,9 @@
     }
   },
   "opCharacters": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Other chars",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Other chars",
+    "mode"  : "Open",
     "values": {
       "startboth"  : "Start with both",
       "findbothCL" : "Find both at current level",
@@ -672,30 +675,10 @@
       "none"       : "They don't exist"
     }
   },
-  "opExp": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Experience",
-    "mode": "Open",
-    "values": {
-      "half"  : "Half",
-      "normal": "Normal",
-      "triple": "Triple"
-    }
-  },
-  "opGold": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Gold",
-    "mode": "Open",
-    "values": {
-      "half"  : "Half",
-      "normal": "Normal",
-      "triple": "Triple"
-    }
-  },
   "opStatusAilments": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Status ailments",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Status ailments",
+    "mode"  : "Open",
     "values": {
       "type"    : "Enemy type",
       "easy"    : "Random (easy)",
@@ -705,35 +688,35 @@
   },
 
   "opComplexity": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Complexity",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Complexity",
+    "mode"  : "Open",
     "values": {
       "easy": "Easy",
       "hard": "Hard"
     }
   },
   "opManaBeastScale": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Mana Beast Stats",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Mana Beast Stats",
+    "mode"  : "Open",
     "values": {
       "vanilla": "Vanilla"
     }
   },
   "opTraps": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Chest traps",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Chest traps",
+    "mode"  : "Open",
     "values": {
       "none": "None",
       "many": "Many"
     }
   },
   "opChestFreq": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Chest drop frequency",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Chest drop frequency",
+    "mode"  : "Open",
     "values": {
       "none"   : "None",
       "low"    : "Low",
@@ -742,50 +725,50 @@
     }
   },
   "opXmasItems": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Random drops",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Random drops",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opMinLevel": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Minimum enemy level",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Minimum enemy level",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opMaxLevel": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Maximum enemy level",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Maximum enemy level",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opDisableHints": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Disable hints",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Disable hints",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opPlatinumMode": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Black out map data",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Black out map data",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
 
   "opBoyRole": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Boy character role",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Boy character role",
+    "mode"  : "Open",
     "values": {
       "random"        : "Random",
       "randomunique"  : "Random (unique)",
@@ -795,9 +778,9 @@
     }
   },
   "opGirlRole": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Girl character role",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Girl character role",
+    "mode"  : "Open",
     "values": {
       "random"        : "Random",
       "randomunique"  : "Random (unique)",
@@ -807,9 +790,9 @@
     }
   },
   "opSpriteRole": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Sprite character role",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Sprite character role",
+    "mode"  : "Open",
     "values": {
       "random"        : "Random",
       "randomunique"  : "Random (unique)",
@@ -820,9 +803,9 @@
   },
 
   "opNumSeeds": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Mana Tree Revival seeds required",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Mana Tree Revival seeds required",
+    "mode"  : "Open",
     "values": {
       "random": "Random",
       "1"     : "1",
@@ -835,9 +818,9 @@
     }
   },
   "opMinSeeds": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Minimum Mana Tree Revival seeds required",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Minimum Mana Tree Revival seeds required",
+    "mode"  : "Open",
     "values": {
       "2": "2",
       "3": "3",
@@ -849,9 +832,9 @@
     }
   },
   "opMaxSeeds": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Maximum Mana Tree Revival seeds required",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Maximum Mana Tree Revival seeds required",
+    "mode"  : "Open",
     "values": {
       "1": "1",
       "2": "2",
@@ -864,33 +847,33 @@
   },
 
   "opShowLevels": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Show enemy level",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Show enemy level",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opAutosave": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Autosave",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Autosave",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opMagicRopeRefactor": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Magic Rope Refactor",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Magic Rope Refactor",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "oopsAllThis": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "But why owls?",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "But why owls?",
+    "mode"  : "Open",
     "values": {
       "random": "Random",
       "0"     : "0 - Rabite",
@@ -979,10 +962,18 @@
       "83"    : "83 - Master Ninja"
     }
   },
+  "opNoFutureLevel": {
+    "$type"    : "MaraBot.Core.NumericOption, MaraBot",
+    "name"     : "\"No Future\" level",
+    "mode"     : "Open",
+    "precision": 0,
+    "min"      : 1,
+    "max"      : 99
+  },
   "opStartWeapon": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Force starting weapon",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Force starting weapon",
+    "mode"  : "Open",
     "values": {
       "0": "0 - Glove",
       "1": "1 - Sword",
@@ -995,76 +986,125 @@
     }
   },
   "opChestsDontRun": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Chests don't run away",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Chests don't run away",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opAiRando": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Enemy AI mode",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Enemy AI mode",
+    "mode"  : "Open",
     "values": {
       "swap": "Swap"
     }
   },
   "opPauseInMenu": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Pause timer in menu",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Pause timer in menu",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opXmasMaps": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Christmas theme",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Christmas theme",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opGPEleRando": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Randomize Grand Palace elements",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Randomize Grand Palace elements",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opAllowLockedItems": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Allow locked items",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Allow locked items",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
   },
   "opSpoilerLog": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Spoiler log",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Spoiler log",
+    "mode"  : "Open",
     "values": {
       "no": "No"
     }
   },
   "opAllWeaponOrbs": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Start with all weapon orbs",
-    "mode": "Open",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Start with all weapon orbs",
+    "mode"  : "Open",
     "values": {
       "yes": "Yes"
     }
+  },
+  "opFastWhipPosts": {
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Fast whip posts",
+    "mode"  : "Open",
+    "values": {
+      "no": "No"
+    }
+  },
+
+  "opExp": {
+    "$type"    : "MaraBot.Core.NumericOption, MaraBot",
+    "name"     : "Experience multiplier",
+    "mode"     : "Open",
+    "precision": 1,
+    "min"      : 0.0,
+    "max"      : 1000.0
+  },
+  "opGold": {
+    "$type"    : "MaraBot.Core.NumericOption, MaraBot",
+    "name"     : "Gold multiplier",
+    "mode"     : "Open",
+    "precision": 1,
+    "min"      : 0.0,
+    "max"      : 1000.0
+  },
+  "opGoldCheckMul": {
+    "$type"    : "MaraBot.Core.NumericOption, MaraBot",
+    "name"     : "Gold check multiplier",
+    "mode"     : "Open",
+    "precision": 1,
+    "min"      : 0.0,
+    "max"      : 50.0
+  },
+  "opGoldDropMul": {
+    "$type"    : "MaraBot.Core.NumericOption, MaraBot",
+    "name"     : "Gold drop multiplier",
+    "mode"     : "Open",
+    "precision": 0,
+    "min"      : 0,
+    "max"      : 255
+  },
+  "opStartGold": {
+    "$type"    : "MaraBot.Core.NumericOption, MaraBot",
+    "name"     : "Starting gold",
+    "mode"     : "Open",
+    "precision": 0,
+    "min"      : 0,
+    "max"      : 65535
   },
 
 
 
   "acDifficulty": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Difficulty",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Difficulty",
+    "mode"  : "AncientCave",
     "values": {
       "hard"      : "Hard",
       "reallyhard": "Really hard",
@@ -1072,76 +1112,76 @@
     }
   },
   "acDialogue": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "NPC Dialogue",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "NPC Dialogue",
+    "mode"  : "AncientCave",
     "values": {
       "demetri": "Demetri Martin"
     }
   },
   "acFilter": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Dialogue language filter",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Dialogue language filter",
+    "mode"  : "AncientCave",
     "values": {
       "yes": "Yes"
     }
   },
   "acMusic": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Random music",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Random music",
+    "mode"  : "AncientCave",
     "values": {
       "no": "No"
     }
   },
   "acBoy": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Boy",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Boy",
+    "mode"  : "AncientCave",
     "values": {
       "no": "No"
     }
   },
   "acGirl": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Girl",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Girl",
+    "mode"  : "AncientCave",
     "values": {
       "no": "No"
     }
   },
   "acSprite": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Sprite",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Sprite",
+    "mode"  : "AncientCave",
     "values": {
       "no": "No"
     }
   },
   "acLength": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Length",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Length",
+    "mode"  : "AncientCave",
     "values": {
       "short": "Short (8 Floors)",
       "long" : "Long (24 Floors)"
     }
   },
   "acBosses": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Bosses",
-    "mode": "AncientCave",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Bosses",
+    "mode"  : "AncientCave",
     "values": {
       "every": "Every floor",
       "final": "Final only"
     }
   },
   "acBiomeTypes": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Floor Types",
-    "mode": "AncientCave",
-    "list": true,
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Floor Types",
+    "mode"  : "AncientCave",
+    "list"  : true,
     "values": {
       "forest"          : "Forest",
       "island"          : "Island",
@@ -1154,9 +1194,9 @@
 
 
   "brDifficulty": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Difficulty",
-    "mode": "BossRush",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Difficulty",
+    "mode"  : "BossRush",
     "values": {
       "hard"      : "Hard",
       "reallyhard": "Really hard",
@@ -1164,33 +1204,33 @@
     }
   },
   "brBoy": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Boy",
-    "mode": "BossRush",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Boy",
+    "mode"  : "BossRush",
     "values": {
       "no": "No"
     }
   },
   "brGirl": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Girl",
-    "mode": "BossRush",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Girl",
+    "mode"  : "BossRush",
     "values": {
       "no": "No"
     }
   },
   "brSprite": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Sprite",
-    "mode": "BossRush",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Sprite",
+    "mode"  : "BossRush",
     "values": {
       "no": "No"
     }
   },
   "brLimitMpAbsorb": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Limit MP Absorb",
-    "mode": "BossRush",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Limit MP Absorb",
+    "mode"  : "BossRush",
     "values": {
       "no": "No"
     }
@@ -1199,9 +1239,9 @@
 
 
   "chDifficulty": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Difficulty",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Difficulty",
+    "mode"  : "Chaos",
     "values": {
       "hard"      : "Hard",
       "reallyhard": "Really hard",
@@ -1209,33 +1249,33 @@
     }
   },
   "chBoy": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Boy",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Boy",
+    "mode"  : "Chaos",
     "values": {
       "no": "No"
     }
   },
   "chGirl": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Girl",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Girl",
+    "mode"  : "Chaos",
     "values": {
       "no": "No"
     }
   },
   "chSprite": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Sprite",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Sprite",
+    "mode"  : "Chaos",
     "values": {
       "no": "No"
     }
   },
   "chFloors": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Length",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Length",
+    "mode"  : "Chaos",
     "values": {
       "vfew" : "Very few",
       "few"  : "Few",
@@ -1244,9 +1284,9 @@
     }
   },
   "chBosses": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Bosses",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Bosses",
+    "mode"  : "Chaos",
     "values": {
       "vfew" : "Very few",
       "few"  : "Few",
@@ -1255,26 +1295,26 @@
     }
   },
   "chMapColors": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Color randomization",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Color randomization",
+    "mode"  : "Chaos",
     "values": {
       "none"      : "None",
       "ridiculous": "Ridiculous"
     }
   },
   "chHealSpellsFirst": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Prioritize heal spells",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Prioritize heal spells",
+    "mode"  : "Chaos",
     "values": {
       "no": "No"
     }
   },
   "chEasyEarlyFloors": {
-    "$type": "MaraBot.Core.EnumOption, MaraBot",
-    "name": "Safer early floors",
-    "mode": "Chaos",
+    "$type" : "MaraBot.Core.EnumOption, MaraBot",
+    "name"  : "Safer early floors",
+    "mode"  : "Chaos",
     "values": {
       "no": "No"
     }


### PR DESCRIPTION
- Split the `List` option type away from option types, and made them a generic property of all options.
- Instead of using enums to dictate an option type, now polymorphism is used with an abstract `Option` class.
- Added the `EnumOption` and `NumericOption` classes, that both derive from `Option`.
- Added deserialisation information to `config/options.json`, to support deserialisation of the new option structure.
- Added the new numeric options (since randomizer v1.29).
- Added some remaining missing options, like "no future level".