### PR TITLE
Updated some options in the weekly settings

### DIFF
--- a/config/mystery.json
+++ b/config/mystery.json
@@ -113,7 +113,7 @@
 
   "opDisableHints": {
     "values": {
-      "yes": 30
+      "yes": 50
     }
   },
 
@@ -152,7 +152,7 @@
   "oopsAllThis": {
     "requirement": "opEnemies=oops",
     "values": {
-      "random": 100
+      "random": 90
     }
   },
 
@@ -204,6 +204,48 @@
       "200": 25,
       "300": 25,
       "400": 25
+    }
+  },
+
+  "starterGear": {
+    "values": {
+      "yes": 25
+    }
+  },
+
+  "funSpeedup": {
+    "values": {
+      "no": 25
+    }
+  },
+
+  "mpAtLevel": {
+    "values": {
+      "no": 25
+    }
+  },
+
+  "fasterMagicLevel": {
+    "values": {
+      "no": 25
+    }
+  },
+
+  "fasterWeaponLevel": {
+    "values": {
+      "no": 25
+    }
+  },
+
+  "trashWeapons": {
+    "values": {
+      "no": 25
+    }
+  },
+
+  "defRefactor": {
+    "values": {
+      "yes": 10
     }
   }
 }

--- a/config/mystery.json
+++ b/config/mystery.json
@@ -227,12 +227,15 @@
 
   "fasterMagicLevel": {
     "values": {
+      "yes": 75,
       "no": 25
     }
   },
 
   "fasterWeaponLevel": {
+    "requirement": "fasterMagicLevel=yes",
     "values": {
+      "yes": 75,
       "no": 25
     }
   },

--- a/config/mystery.json
+++ b/config/mystery.json
@@ -227,15 +227,13 @@
 
   "fasterMagicLevel": {
     "values": {
-      "yes": 75,
       "no": 25
     }
   },
 
   "fasterWeaponLevel": {
-    "requirement": "fasterMagicLevel=yes",
+    "requirement": "^((?!fasterMagicLevel=no).)*$",
     "values": {
-      "yes": 75,
       "no": 25
     }
   },


### PR DESCRIPTION
- Increased opDisableHints to 50%
- Give a chance of 10% for all owls when `opEnemies==oops".
- 25% for starter gear
- 25% for no fun speedup
- 25% for no mp restore at level up
- 25% for no faster magic level up
- 25% for no faster weapon level up
- 25% for no trash weapons
- 10% for defense refactor
